### PR TITLE
DBZ-82 Updated documentation to be a bit more clear

### DIFF
--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -56,7 +56,9 @@ Running a MySQL server with binary logging enabled does slightly reduce performa
 [[enabling-gtids-optional]]
 === Enabling GTIDs (optional)
 
-The MySQL server can be configured to use https://dev.mysql.com/doc/refman/5.6/en/replication-gtids.html[GTID-based replication]. Global transaction identifiers, or GTIDs, were introduced in MySQL 5.6.5, and they uniquely identify a transaction that occurred on a particular server within a cluster. Using GTIDs greatly simplifies replication and makes it possible to easily confirm whether masters and slaves are consistent. Enabling GTIDs can be done in the MySQL server configuration file, and will look similar to the following fragement:
+The MySQL server can be configured to use https://dev.mysql.com/doc/refman/5.6/en/replication-gtids.html[GTID-based replication]. Global transaction identifiers, or GTIDs, were introduced in MySQL 5.6.5, and they uniquely identify a transaction that occurred on a particular server within a cluster. Using GTIDs greatly simplifies replication and makes it possible to easily confirm whether masters and slaves are consistent. *Note that if you're using an earlier version of MySQL, you will not be able to enable GTIDs.*
+
+Enabling GTIDs can be done in the MySQL server configuration file, and will look similar to the following fragement:
 
 [source]
 ----


### PR DESCRIPTION
GTIDs are available in MySQL 5.6.5, so made it a bit more clear that GTIDs cannot be used with earlier versions of MySQL.