### PR TITLE
DBZ-91 Documented the MySQL connector's data type mappings for 0.3.0

### DIFF
--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -663,6 +663,224 @@ As of Kafka 0.10, the JSON converter provided by Kafka Connect never results in 
 In the meantime, consider using the link:/docs/faq#avro-converter[Avro Converter], which does properly return a null value and will thus take full advantage of Kafka log compaction.
 ====
 
+[[data-types]]
+=== Data types
+
+As described above, the MySQL connector represents the changes to rows with events that are structured like the table in which the row exist. The event contains a field for each column value, and how that value is represented in the event depends on the MySQL data type of the column. This section describes this mapping.
+
+The following table describes how the connector maps each of the MySQL data types to a _literal type_ and _semantic type_ within the events' fields. Here, the _literal type_ describes how the value is literally represented using Kafka Connect schema types, namely `INT8`, `INT16`, `INT32`, `INT64`, `FLOAT32`, `FLOAT64`, `BOOLEAN`, `STRING`, `BYTES`, `ARRAY`, `MAP`, and `STRUCT`. The _semantic type_ describes how the Kafka Connect schema captures the _meaning_ of the field using the name of the Kafka Connect schema for the field.
+
+[cols="20%a,15%a,30%a,35%a",width=100,options="header,footer",role="table table-bordered table-striped"]
+|=======================
+|MySQL Data Type
+|Literal type (schema type)
+|Semantic type (schema name)
+|Notes
+
+|`BOOLEAN`, `BOOL`
+|`BOOLEAN`
+|n/a
+|
+
+|`BIT(1)` 
+|`BOOLEAN`
+|n/a
+|
+
+|`BIT( > 1)` 
+|`BYTES`
+|`io.debezium.data.Bits`
+|The `length` schema parameter contains an integer representing the number of bits.
+
+|`TINYINT` 
+|`INT8`
+|n/a
+|
+
+|`SMALLINT[(M)]` 
+|`INT16`
+|n/a
+|
+
+|`MEDIUMINT[(M)]` 
+|`INT32`
+|n/a
+|
+
+|`INT`, `INTEGER[(M)]` 
+|`INT32`
+|n/a
+|
+
+|`BIGINT[(M)]` 
+|`INT64`
+|n/a
+|
+
+|`REAL[(M,D)]` 
+|`FLOAT32`
+|n/a
+|
+
+|`FLOAT[(M,D)]` 
+|`FLOAT64`
+|n/a
+|
+
+|`DOUBLE[(M,D)]` 
+|`FLOAT64`
+|n/a
+|
+
+|`DECIMAL[(M[,D])]` 
+|`BYTES`
+|`org.apache.kafka.connect.data.Decimal`
+|The `scaled` schema parameter contains an integer representing how many digits the decimal point was shifted.
+
+|`CHAR(M)]` 
+|`STRING`
+|n/a
+|
+
+|`VARCHAR(M)]` 
+|`STRING`
+|n/a
+|
+
+|`BINARY(M)]` 
+|`BYTES`
+|n/a
+|
+
+|`VARBINARY(M)]` 
+|`BYTES`
+|n/a
+|
+
+|`TINYBLOB` 
+|`BYTES`
+|n/a
+|
+
+|`TINYTEXT` 
+|`STRING`
+|n/a
+|
+
+|`BLOB` 
+|`BYTES`
+|n/a
+|
+
+|`TEXT` 
+|`STRING`
+|n/a
+|
+
+|`MEDIUMBLOB` 
+|`BYTES`
+|n/a
+|
+
+|`MEDIUMTEXT` 
+|`STRING`
+|n/a
+|
+
+|`LONGBLOB` 
+|`BYTES`
+|n/a
+|
+
+|`LONGTEXT` 
+|`STRING`
+|n/a
+|
+
+|`ENUM` 
+|`STRING`
+|`io.debezium.data.Enum`
+|The `allowed` schema parameter contains the comma-separated list of allowed values.
+
+|`SET` 
+|`STRING`
+|`io.debezium.data.EnumSet`
+|The `allowed` schema parameter contains the comma-separated list of allowed values.
+
+|`YEAR[(2\|4)]` 
+|`INT32`
+|`io.debezium.time.Year`
+|
+
+|`TIMSTAMP[(M)]`
+|`STRING`
+|`io.debezium.time.ZonedTimestamp`
+| Contains an ISO8601 formatted date and time in a particular time zone.
+
+|=======================
+
+Other than MySQL's `TIMESTAMP` data type, the other MySQL temporal types depend on the value of the `time.precision.mode` configuration property. When this value is set to `connect`, then the connector will use the predefined Kafka Connect logical types:
+
+[cols="15%a,15%a,35%a,35%a",width=100,options="header,footer",role="table table-bordered table-striped"]
+|=======================
+|MySQL Data Type
+|Literal type (schema type)
+|Semantic type (schema name)
+|Notes
+
+|`DATE` 
+|`INT32`
+|`org.apache.kafka.connect.data.Date`
+| Represents the number of days since epoch.
+
+|`TIME[(M)]` 
+|`INT64`
+|`org.apache.kafka.connect.data.Time`
+| Represents the number of milliseconds since midnight.
+
+|`DATETIME[(M)]` 
+|`INT64`
+|`org.apache.kafka.connect.data.Timestamp`
+| Represents the number of milliseconds since epoch.
+
+|=======================
+
+However, when `time.precision.mode` configuration property is set to `adaptive`, then the connector will base the literal type and semantic type for the temporal types on the column's data type definition:
+
+[cols="15%a,15%a,35%a,35%a",width=100,options="header,footer",role="table table-bordered table-striped"]
+|=======================
+|MySQL Data Type
+|Literal type (schema type)
+|Semantic type (schema name)
+|Notes
+
+|`DATE` 
+|`INT32`
+|`io.debezium.time.Date`
+| Represents the number of days since epoch.
+
+|`TIME`, `TIME(0)`, `TIME(1)`, `TIME(2)`, `TIME(3)` 
+|`INT32`
+|`io.debezium.time.Time`
+| Represents the number of milliseconds past midnight.
+
+|`TIME(4)`, `TIME(5)`, `TIME(6)` 
+|`INT64`
+|`io.debezium.time.MicroTime`
+| Represents the number of microseconds past midnight.
+
+|`DATETIME`, `DATETIME(0)`, `DATETIME(1)`, `DATETIME(2)`, `DATETIME(3)` 
+|`INT64`
+|`io.debezium.time.Timestamp`
+| Represents the number of milliseconds past epoch.
+
+|`DATETIME(4)`, `DATETIME(5)`, `DATETIME(6)`
+|`INT64`
+|`io.debezium.time.MicroTimestamp`
+| Represents the number of microseconds past epoch.
+
+|=======================
+
 
 
 [[fault-tolerance]]


### PR DESCRIPTION
Added to the MySQL connector documentation the mapping from MySQL data types to Kafka Connect schemas.