### PR TITLE
DBZ-306 update docs to reflect changes in event key’s payload

### DIFF
--- a/docs/connectors/mongodb.asciidoc
+++ b/docs/connectors/mongodb.asciidoc
@@ -200,15 +200,16 @@ The `schema` portion of the key contains a Kafka Connect schema describing what 
 This example used a document with an integer identifier, but any valid MongoDB document identifier (including documents) will work. The value of the `id` field in the payload will simply be a string representing a MongoDB extended JSON serialization (strict mode) of the original document's `_id` field. Find below a few examples showing how `_id` fields of 
 different types will get encoded as the event key's payload:
 
-* `_id` of type integer e.g. 1234 -> `{ "id" : "1234" }`
-* `_id` of type float e.g. of 12.34 -> `{ "id" : "12.34" }`
-* `_id` of type string e.g. "1234" -> `{ "id" : "\"1234\"" }`
-* `_id` of type document e.g. { "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] } -> `{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
-
-For extended JSON types (e.g. ObjectId, Binary,...) the encoding works in accordance with MongoDB's serialization specs:
-
-* `_id` of type ObjectId e.g. "596e275826f08b2730779e1f" -> `{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
-* `_id` of type Binary e.g. "a2Fma2E=" -> `{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
+[options="header"]
+|==========================================
+|Type    |MongoDB `_id` Value|Key's payload
+|Integer |1234|`{ "id" : "1234" }`
+|Float   |12.34|`{ "id" : "12.34" }`
+|String  |"1234"|`{ "id" : "\"1234\"" }`
+|Document|{ "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] }|`{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
+|ObjectId|ObjectId("596e275826f08b2730779e1f")|`{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
+|Binary  |BinData("a2Fma2E=",0)|`{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
+|==========================================
 
 [WARNING]
 ====

--- a/docs/connectors/mongodb.asciidoc
+++ b/docs/connectors/mongodb.asciidoc
@@ -160,7 +160,7 @@ Debezium and Kafka Connect are designed around _continuous streams of event mess
 [[change-events-key]]
 ==== Change event's key
 
-For a given collection, the change event's key will be a structure that contains a single `_id` field whose value will be the string representation of the document's identifier. Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database with a `customers` collection containing documents such as:
+For a given collection, the change event's key will be a structure that contains a single `id` field. Its value will be the document's identifier represented as string which is derived from the https://docs.mongodb.com/manual/reference/mongodb-extended-json/[MongoDB extended JSON serialization in strict mode]. Consider a connector with a logical name of `fulfillment`, a replica set containing an `inventory` database with a `customers` collection containing documents such as:
 
 [source,json,indent=0]
 ----
@@ -190,14 +190,25 @@ Every change event for the `customers` collection will feature the same key stru
       ]
     },
     "payload": {
-      "_id": "1004"
+      "id": "1004"
     }
   }
 ----
 
-The `schema` portion of the key contains a Kafka Connect schema describing what is in the payload portion, and in our case that means that the `payload` value is not optional, is a structure defined by a schema named `fulfillment.inventory.customers.Key`, and has one required field named `_id` of type `string`. If we look at the value of the key's `payload` field, we'll see that it is indeed a structure (which in JSON is just an object) with a single `_id` field, whose value is a string containing the integer `1004`.
+The `schema` portion of the key contains a Kafka Connect schema describing what is in the payload portion, and in our case that means that the `payload` value is not optional, is a structure defined by a schema named `fulfillment.inventory.customers.Key`, and has one required field named `id` of type `string`. If we look at the value of the key's `payload` field, we'll see that it is indeed a structure (which in JSON is just an object) with a single `id` field, whose value is a string containing the integer `1004`.
 
-This example used a document with an integer identifier, but any valid MongoDB document identifier (including documents) will work. The value of the `_id` field in the payload will simply be the string representation of that value.
+This example used a document with an integer identifier, but any valid MongoDB document identifier (including documents) will work. The value of the `id` field in the payload will simply be a string representing a MongoDB extended JSON serialization (strict mode) of the original document's `_id` field. Find below a few examples showing how `_id` fields of 
+different types will get encoded as the event key's payload:
+
+* `_id` of type integer e.g. 1234 -> `{ "id" : "1234" }`
+* `_id` of type float e.g. of 12.34 -> `{ "id" : "12.34" }`
+* `_id` of type string e.g. "1234" -> `{ "id" : "\"1234\"" }`
+* `_id` of type document e.g. { "hi" : "kafka", "nums" : [10.0, 100.0, 1000.0] } -> `{ "id" : "{\"hi\" : \"kafka\", \"nums\" : [10.0, 100.0, 1000.0]}" }`
+
+For extended JSON types (e.g. ObjectId, Binary,...) the encoding works in accordance with MongoDB's serialization specs:
+
+* `_id` of type ObjectId e.g. "596e275826f08b2730779e1f" -> `{ "id" : "{\"$oid\" : \"596e275826f08b2730779e1f\"}" }`
+* `_id` of type Binary e.g. "a2Fma2E=" -> `{ "id" : "{\"$binary\" : \"a2Fma2E=\", \"$type\" : \"00\"}" }`
 
 [WARNING]
 ====


### PR DESCRIPTION
also add several examples showing how different _id field types will get encoded as JSON strings