### PR TITLE
Fixing incorrect variable names in Avro instructions

### DIFF
--- a/docs/configuration/avro.asciidoc
+++ b/docs/configuration/avro.asciidoc
@@ -84,10 +84,10 @@ docker run -it --rm --name connect \
     -e GROUP_ID=1 \
     -e CONFIG_STORAGE_TOPIC=my_connect_configs \
     -e OFFSET_STORAGE_TOPIC=my_connect_offsets \
-    -e CONNECT_KEY_CONVERTER=io.confluent.connect.avro.AvroConverter \
-    -e CONNECT_VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter \
-    -e CONNECT_INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
-    -e CONNECT_INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
+    -e KEY_CONVERTER=io.confluent.connect.avro.AvroConverter \
+    -e VALUE_CONVERTER=io.confluent.connect.avro.AvroConverter \
+    -e INTERNAL_KEY_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
+    -e INTERNAL_VALUE_CONVERTER=org.apache.kafka.connect.json.JsonConverter \
     -e CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081 \
     -e CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL=http://schema-registry:8081 \
     -p 8083:8083 debezium/connect:{debezium-docker-label}


### PR DESCRIPTION
Our image defines its [own environment variables](https://github.com/debezium/docker-images/blob/master/connect-base/0.6/docker-entrypoint.sh#L23-L26), overriding the existing `CONNECT_...` ones.

I'm not sure whether that's really a good idea, but as we started with it, we should also do it for the two registry URL ones which currently need to be given via the original variables. I'll send a PR for the images repo for that.