### PR TITLE
DBZ-482 Clarifying requirement of database history and schema change …

### DIFF
--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -162,6 +162,12 @@ When the connector restarts after having crashed or been stopped gracefully, the
 
 This database history topic is for connector use only, but the connector can optionally generate _schema change events_ on a different topic that is intended for consumer applications. We'll cover this in the link:#schema-change-topic[Schema Change Topic] section.
 
+[NOTE]
+====
+It is vital that there is a global order of the events in the database schema history, therefore the database history topic must not be partitioned.
+This means a partition count of 1 must be specified when creating this topic.
+When relying on auto topic creation, make sure that Kafka's `num.partitions` configuration option (the default number of partitions) is set to 1.
+====
 
 [[snapshots]]
 === Snapshots
@@ -242,6 +248,13 @@ It is often useful for applications to consume events that describe the changes 
 [IMPORTANT]
 ====
 The link:#database-schema-history[database history topic] and _schema change topic_ both contain events with the DDL statement. However, we've designed the events on the schema change topic to be easier to consume, so they are more granular and always have the database name. If you're going to consume schema change events, be sure to use the schema change topic and _never_ consume the database history topic.
+====
+
+[NOTE]
+====
+In order to keep the correct order of schema changes, the schema change topic must not be partitioned.
+This means a partition count of 1 must be specified when creating this topic.
+When relying on auto topic creation, make sure that Kafka's `num.partitions` configuration option (the default number of partitions) is set to 1.
 ====
 
 Each message written to the schema change topic will have a message key that contains the name of the database to which the client was connected and using when they applied the DDL statement(s):


### PR DESCRIPTION
…topics to have a single partition

https://issues.jboss.org/browse/DBZ-482

In fact it may not be strictly needed, as we explicitly specify 0 as the partition when writing to these topics. But then using partitioned topics adds any benefits, so it seems reasonable to recommend against it in the docs, also acting as a safety net should we get it wrong in the implementation.