### PR TITLE
Use Strimzi 0.1.0  instead of master

### DIFF
--- a/docs/openshift.asciidoc
+++ b/docs/openshift.asciidoc
@@ -20,8 +20,8 @@ First we install the Kafka broker and Kafka Connect templates into our OpenShift
 
 [listing,options="nowrap"]
 ----
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi/master/kafka-statefulsets/resources/openshift-template.yaml
-oc create -f https://raw.githubusercontent.com/strimzi/strimzi/master/kafka-connect/s2i/resources/openshift-template.yaml
+oc create -f https://raw.githubusercontent.com/strimzi/strimzi/0.1.0/kafka-statefulsets/resources/openshift-template.yaml
+oc create -f https://raw.githubusercontent.com/strimzi/strimzi/0.1.0/kafka-connect/s2i/resources/openshift-template.yaml
 ----
 
 Next we will create a Kafka Connect image with the Debezium connectors installed and then deploy a Kafka broker cluster and a Kafka Connect cluster:


### PR DESCRIPTION
The website should not be using files from the master branch, which might be changing. It should use the release instead. This PR changes the links to the files from the 0.1.0 release.