### PR TITLE
DBZ-537 Document engine properties

### DIFF
--- a/docs/embedded.asciidoc
+++ b/docs/embedded.asciidoc
@@ -199,6 +199,73 @@ Recall that when the JVM shuts down, it only waits for daemon threads. Therefore
 
 Your application should always properly stop the engine to ensure graceful and complete shutdown and that each source record is sent to the application exactly one time. For example, do not rely upon shutting down the `ExecutorService`, since that interrupts the running threads. Although the `EmbeddedEngine` will indeed terminate when its thread is interrupted, the engine may not terminate cleanly, and when your application is restarted it may see some of the same source records that it had processed just prior to the shutdown.
 
+[[engine-properties]]
+== Engine properties
+
+The following configuration properties are _required_ unless a default value is available (for the sake of text formatting the package names of Java classes are replaced with `<...>`). 
+
+[cols="35%a,10%a,55%a",options="header,footer",role="table table-bordered table-striped"]
+|=======================
+|Property
+|Default
+|Description
+
+|`name`
+|
+|Unique name for the connector instance.
+
+|`connector.class`
+|
+|The name of the Java class for the connector, e.g  `<...>.MySqlConnector` for the MySQL connector.
+
+|`offset.storage`
+|`<...>.FileOffsetBackingStore`
+|The name of the Java class that is responsible for persistence of connector offsets.
+It must implement `<...>.OffsetBackingStore` interface.
+
+|`offset.storage.file.filename`
+|`""`
+|Path to file where offsets are to be stored.
+Required when `offset.storage` is set to the `<...>.FileOffsetBackingStore`.
+
+|`offset.storage.topic`
+|`""`
+|The name of the Kafka topic where offsets are to be stored.
+Required when `offset.storage` is set to the `<...>.KafkaOffsetBackingStore`.
+
+|`offset.storage.partitions`
+|`""`
+|The number of partitions used when creating the offset storage topic.
+Required when `offset.storage` is set to the `<...>.KafkaOffsetBackingStore`.
+
+|`offset.storage.replication.factor`
+|`""`
+|Replication factor used when creating the offset storage topic.
+Required when `offset.storage` is set to the `<...>.KafkaOffsetBackingStore`.
+
+|`offset.commit.policy`
+|`<...>.PeriodicCommitOffsetPolicy`
+|The name of the Java class of the commit policy.
+It defines when offsets commit has to be triggered based on the number of events processed and the time elapsed since the last commit. This class must implement the interface `<...>.OffsetCommitPolicy`.
+The default is a periodic commity policy based upon time intervals.
+
+|`offset.flush.interval.ms`
+|`60000`
+|Interval at which to try committing offsets. The default is 1 minute.
+
+|`offset.flush.timeout.ms`
+|`5000`
+|Maximum number of milliseconds to wait for records to flush and partition offset data to be committed to offset storage before cancelling the process and restoring the offset data to be committed in a future attempt. The default is 5 seconds.
+
+|`internal.key.converter`
+|`<...>.JsonConverter`
+|The Converter class that should be used to serialize and deserialize key data for offsets. The default is JSON converter.
+
+|`internal.value.converter`
+|`<...>.JsonConverter`
+|The Converter class that should be used to serialize and deserialize value data for offsets. The default is JSON converter.
+|=======================
+
 == Handling failures
 
 When the engine executes, its connector is actively recording the source offset inside each source record, and the engine is periodically flushing those offsets to persistent storage. When the application and engine shutdown normally or crash, when they are restarted the engine and its connector will resume reading the source information *from the last recorded offset*.


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-537

For the sake of fromatting I created a convention in the table that package names are replaced with `<...>` string. Otherwise the table would overflow or we we would need to fill class names with `ZWSP` to enable breaking them in the text flow.