### PR TITLE
[DBZ-602] - update documentation

### DIFF
--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -1536,7 +1536,7 @@ _0.7.3 and later_
 
 `extended` In some cases where clients are submitting operations that MySQL excludes from REPEATABLE READ semantics, it may be desirable to block all writes for the entire duration of the snapshot. For these such cases, use this option. +
 
-`none` Will prevent the connector from acquiring any table locks during the snapshot process. This value can only be used in combination with configuration `snapshot.mode` values of `schema_only` or `schema_only_recovery`.
+`none` Will prevent the connector from acquiring any table locks during the snapshot process. This value can only be used in combination with configuration `snapshot.mode` values of `schema_only` or `schema_only_recovery` and is only safe to use if no schema changes are happening while the snapshot is taken.
 
 |`snapshot.minimal.locks` +
 _deprecated since 0.7.3_

--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -1527,10 +1527,27 @@ _Note:_ This feature should be considered an incubating one. We need a feedback 
 
 `schema_only_recovery` is a recovery option for an existing connector to recover a corrupted or lost database history topic, or to periodically "clean up" a database history topic (which requires infinite retention) that may be growing unexpectedly.
 
-|`snapshot.minimal.locks`
+|`snapshot.locking.mode` +
+_0.7.3 and later_
+|`minimal`
+|Controls if and how long the connector holds onto the global MySQL read lock (preventing any updates to the database) while it is performing a snapshot.  There are three possible values `minimal`, `extended`, and `none`. +
+
+`minimal` The connector holds the global read lock for just the initial portion of the snapshot while the connector reads the database schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each table, and this can be done in a consistent fashion using the REPEATABLE READ transaction even when the global read lock is no longer held and while other MySQL clients are updating the database. +
+
+`extended` In some cases where clients are submitting operations that MySQL excludes from REPEATABLE READ semantics, it may be desirable to block all writes for the entire duration of the snapshot. For these such cases, use this option. +
+
+`none` Will prevent the connector from acquiring any table locks during the snapshot process. This value can only be used in combination with configuration `snapshot.mode` values of `schema_only` or `schema_only_recovery`.
+
+|`snapshot.minimal.locks` +
+_deprecated since 0.7.3_
 |`true`
 |Controls how long the connector holds onto the global MySQL read lock (preventing any updates to the database) while it is performing a snapshot. The default is `true`, meaning the connector holds the global read lock for just the initial portion of the snapshot while the connector reads the database schemas and other metadata. The remaining work in a snapshot involves selecting all rows from each table, and this can be done in a consistent fashion using the `REPEATABLE READ` transaction even when the global read lock is no longer held and while other
-MySQL clients are updating the database. However, in some cases where clients are submitting operations that MySQL excludes from `REPEATABLE READ` semantics, it may be desirable to _block all writes_ for the entire duration of the snapshot. In only such cases, set this property to `false`.
+MySQL clients are updating the database. However, in some cases where clients are submitting operations that MySQL excludes from `REPEATABLE READ` semantics, it may be desirable to _block all writes_ for the entire duration of the snapshot. In only such cases, set this property to `false`. +
+_Deprecated:_ This option has been deprecated and replaced with the `snapshot.locking.mode` configuration option.  This option will be removed in a future release. +
+
+A `snapshot.minimal.locks` value of `true` should be replaced with `snapshot.locking.mode` set to `minimal`. +
+
+A `snapshot.minimal.locks` value of `false` should be replaced with `snapshot.locking.mode` set to `extended`.
 
 |`snapshot.select.statement.overrides` +
 0.7.0 and later


### PR DESCRIPTION
Updated documentation for issue DBZ-602 (https://github.com/debezium/debezium/pull/456)

New configuration entry for snapshot.locking.mode:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/571653/36997144-b0072d94-2086-11e8-9adb-dc9b948e83c5.png">


Deprecation notice for snapshot.mininal.locks:

<img width="408" alt="image" src="https://user-images.githubusercontent.com/571653/36997108-94c46a10-2086-11e8-96f3-057de732b28b.png">
