### PR TITLE
Fix mysql and mongodb maximum batch and queue size documentation

### DIFF
--- a/docs/connectors/mongodb.asciidoc
+++ b/docs/connectors/mongodb.asciidoc
@@ -635,13 +635,13 @@ The following _advanced_ configuration properties have good defaults that will w
 |Default
 |Description
 
+|`max.queue.size`
+|`8192`
+|Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the oplog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified in the `max.queue.size` property.
+
 |`max.batch.size`
 |`2048`
-|Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the oplog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 2048, and should always be larger than the maximum queue size specified in the `max.queue.size` property.
-
-|`max.queue.size`
-|`1024`
-|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 1024.
+|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
 |`poll.interval.ms`
 |`1000`

--- a/docs/connectors/mysql.asciidoc
+++ b/docs/connectors/mysql.asciidoc
@@ -1460,13 +1460,13 @@ The following configuration properties are _required_ unless a default value is 
 (make sure that link:/docs/configuration/logging/[the logger] is set to the `WARN` or `ERROR` level). +
 `ignore` will cause the problematic event to be skipped.
 
+|`max.queue.size`
+|`8192`
+|Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the binlog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 8192, and should always be larger than the maximum batch size specified in the `max.batch.size` property.
+
 |`max.batch.size`
 |`2048`
-|Positive integer value that specifies the maximum size of the blocking queue into which change events read from the database log are placed before they are written to Kafka. This queue can provide backpressure to the binlog reader when, for example, writes to Kafka are slower or if Kafka is not available. Events that appear in the queue are not included in the offsets periodically recorded by this connector. Defaults to 2048, and should always be larger than the maximum queue size specified in the `max.queue.size` property.
-
-|`max.queue.size`
-|`1024`
-|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 1024.
+|Positive integer value that specifies the maximum size of each batch of events that should be processed during each iteration of this connector. Defaults to 2048.
 
 |`poll.interval.ms`
 |`1000`


### PR DESCRIPTION
- The default value for `max.queue.size` seems to be wrong: https://github.com/debezium/debezium/blob/b5856f37c756debe5a52f44a422340194c0b5e7a/debezium-core/src/main/java/io/debezium/config/CommonConnectorConfig.java#L22
- `max.queue.size` and `max.batch.size` should be switched