### PR TITLE
Add documentation for schema.refresh.mode option

### DIFF
--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -1365,6 +1365,20 @@ Disabled by default.
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
+|`schema.refresh.mode` +
+0.9.0.Alpha2 and later
+|`columns_diff`
+|Specify the conditions that trigger a refresh of the in-memory schema for a table.
+
+`columns_diff` (the default) is the safest mode, ensuring the in-memory schema stays in-sync with the database table's schema at all times.
+
+`columns_diff_exclude_unchanged_toast` instructs the connector to refresh the in-memory schema cache if there is a discrepancy between it
+and the schema derived from the incoming message, unless unchanged TOASTable data fully accounts for the discrepancy.
+
+This setting can improve connector performance significantly if there are frequently-updated tables that
+have TOASTed data that are rarely part of these updates. However, it is possible for the in-memory schema to
+become outdated if TOASTable columns are dropped from the table.
+
 |=======================
 
 The connector also supports _pass-through_ configuration properties that are used when creating the Kafka producer and consumer.

--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -1366,7 +1366,7 @@ Disabled by default.
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
 |`schema.refresh.mode` +
-0.9.0.Alpha2 and later
+0.9.0 and later
 |`columns_diff`
 |Specify the conditions that trigger a refresh of the in-memory schema for a table.
 


### PR DESCRIPTION
Documentation for PostgreSQL connector configuration updates from https://issues.jboss.org/browse/DBZ-911.