### PR TITLE
DBZ-925 Change `array.encoding` to correct options

### DIFF
--- a/docs/configuration/mongodb-event-flattening.asciidoc
+++ b/docs/configuration/mongodb-event-flattening.asciidoc
@@ -83,14 +83,14 @@ To bypass this impedance mismatch it is possible to encode the array in two diff
 ----
 transforms=unwrap,...
 transforms.unwrap.type=io.debezium.connector.mongodb.transforms.UnwrapFromMongoDbEnvelope
-transforms.unwrap.array.encoding=<array|struct>
+transforms.unwrap.array.encoding=<array|document>
 ----
 
 Value `array` (the default) will encode arrays as the array datatype.
 It is user's responsibility to ensure that all elements for a given array instance are of the same time.
 This option is a restricting one but offers easy processing of arrays by downstream clients.
 
-Value `struct` will convert the array into a *struct* of *structs* in the similar way as done by http://bsonspec.org/[BSON serialization].
+Value `document` will convert the array into a *struct* of *structs* in the similar way as done by http://bsonspec.org/[BSON serialization].
 The main *struct* contains fields named `_0`, `_1`, `_2` etc. where the name represents the index of the element in the array.
 Every element is then passed as the value for the give field.
 


### PR DESCRIPTION
As in https://github.com/debezium/debezium/pull/672
Both documentation were wrong pointing to a value `struct` when it should've been `document`