### PR TITLE
Remove references to RDS using older version of wal2json

### DIFF
--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -62,12 +62,10 @@ It is possible to monitor PostgreSQL database running in https://aws.amazon.com/
 
 * The instance parameter `rds.logical_replication` is set to `1`.
 * Verify that `wal_level` parameter is set to `logical`; this might not be the case in multi-zone replication setups.
-* Set `plugin.name` Debezium parameter to `wal2json`. Note that RDS is running older version of the plug-in. We are trying to detect that it is the case but the detection is not 100 % reliable. In case of problems use `wal2json_rds` value to manually override the detection routine.
+* Set `plugin.name` Debezium parameter to `wal2json`.
 * Use database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
 
 ==== Known limitations
-The `wal2json` plug-in used in Amazon RDS environment is not fully up-to-date with the recent additions to the upstream project.
-Till the plug-in is updated please expect certain limits in capabilities vs the plug-in version used by Debezium.
 
 * The replication message does not carry information about type constraints like length or scale or `NULL`/`NOT NULL`.
 Debezium is thus not able to detect changes in type constraints (https://issues.jboss.org/browse/DBZ-504[DBZ-504]).

--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -74,6 +74,7 @@ In that case, replication messages received from the database may not carry comp
 which in turn might cause creation of messages with an inconsistent schema for a short period of time in case of changes to a column's definition.
 
 As of January 2019, the following Postgres versions on RDS come with an up-to-date version of wal2json and thus should be used:
+
 * Postgres 9.6: 9.6.10 and newer
 * Postgres 10: 10.5 and newer
 * Postgres 11: any version

--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -65,10 +65,19 @@ It is possible to monitor PostgreSQL database running in https://aws.amazon.com/
 * Set `plugin.name` Debezium parameter to `wal2json`.
 * Use database master account for replication as RDS currently does not support setting of `REPLICATION` privilege for another account.
 
-==== Known limitations
+[IMPORTANT]
+====
+You should make sure to use the latest versions of Postgres 9.6, 10 or 11 on Amazon RDS.
+Otherwise, older versions of the wal2json plug-in may be installed
+(see https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html[the official documentation] for the exact wal2json versions installed on Amazon RDS).
+In that case, replication messages received from the database may not carry complete information about type constraints like length or scale or `NULL`/`NOT NULL`,
+which in turn might cause creation of messages with an inconsistent schema for a short period of time in case of changes to a column's definition.
 
-* The replication message does not carry information about type constraints like length or scale or `NULL`/`NOT NULL`.
-Debezium is thus not able to detect changes in type constraints (https://issues.jboss.org/browse/DBZ-504[DBZ-504]).
+As of January 2019, the following Postgres versions on RDS come with an up-to-date version of wal2json and thus should be used:
+* Postgres 9.6: 9.6.10 and newer
+* Postgres 10: 10.5 and newer
+* Postgres 11: any version
+====
 
 [[output-plugin]]
 === Installing the logical decoding output plugin


### PR DESCRIPTION
The caveats about wal2json being out of date in RDS can be removed since running a `git blame` shows those parts of the README.md are dated on Dec 20, 2017 and Mar 14, 2018, resp. That said, AWS RDS 9.6.10, 10.5 and 11 are all using wal2json commit hash 01c5c1ec which is dated Apr 29, 2018. I assume it's fine now. We have been testing postgres RDS and have not come across issues yet setting up Debezium.

Reference:
- AWS documention: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html#PostgreSQL.Concepts.General.version105
- wal2json version 01c5c1ec https://github.com/eulerto/wal2json/commit/01c5c1ec37b2c27baf00649c028b03936427596a