### PR TITLE
Fixes typos in the FAQ documentation

### DIFF
--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -10,7 +10,7 @@ toc::[level=2]
 
 == What is Debezium?
 
-Debezium is a set of distributed services capture row-level changes in your databases so that your applications can see and respond to those changes. Debezium records in a transaction log all row-level changes committed to each database table. Each application simply reads the transaction logs their interested in, and they see all of the events in the same order in which they occurred.
+Debezium is a set of distributed services that capture row-level changes in your databases so that your applications can see and respond to those changes. Debezium records in a transaction log all row-level changes committed to each database table. Each application simply reads the transaction logs their interested in, and they see all of the events in the same order in which they occurred.
 
 == Where did the name "Debezium" come from?
 
@@ -37,7 +37,7 @@ The primary use of Debezium is to enable applications to respond almost immediat
 
 == Why is Debezium a distributed system?
 
-Debezium is architected to be tolerant of faults and failures, and the only effectively way to do that is with a distributed system. Debezium distributes the monitoring processes, or _connectors_, across multiple machines so that, if anything does wrong, the connectors can be restarted. The events are recorded and replicated across multiple machines to minimize risk of information loss.
+Debezium is architected to be tolerant of faults and failures, and the only effectively way to do that is with a distributed system. Debezium distributes the monitoring processes, or _connectors_, across multiple machines so that, if anything goes wrong, the connectors can be restarted. The events are recorded and replicated across multiple machines to minimize risk of information loss.
 
 == Can my application directly monitor a single database?
 
@@ -144,7 +144,7 @@ This name will be published by Zookeeper to clients asking for the Kafka broker'
 
 == What database size can be handled with the default memory settings for the Connect image?
 
-The memory consumption during start-up and runtime depends on the total number if tables in the database that is monitored by Debezium, the number of columns in each table and also the amount of events coming from the database.
+The memory consumption during start-up and runtime depends on the total number of tables in the database that is monitored by Debezium, the number of columns in each table and also the amount of events coming from the database.
 As a rule of thumb the default memory settings (maximum heap set to 256 MB) will manage to handle databases where the total count of columns across all tables is less than 10000.
 
 == How to retrieve DECIMAL field from binary representation?


### PR DESCRIPTION
Addresses a few typos found on the FAQ documentation