### PR TITLE
Update tutorial.asciidoc to note curl discrepancy on Windows

### DIFF
--- a/docs/tutorial.asciidoc
+++ b/docs/tutorial.asciidoc
@@ -343,6 +343,20 @@ Using the same terminal, we'll use `curl` to submit to our Kafka Connect service
     $ curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" localhost:8083/connectors/ -d '{ "name": "inventory-connector", "config": { "connector.class": "io.debezium.connector.mysql.MySqlConnector", "tasks.max": "1", "database.hostname": "mysql", "database.port": "3306", "database.user": "debezium", "database.password": "dbz", "database.server.id": "184054", "database.server.name": "dbserver1", "database.whitelist": "inventory", "database.history.kafka.bootstrap.servers": "kafka:9092", "database.history.kafka.topic": "dbhistory.inventory" } }'
 ----
 
+[NOTE]
+====
+Windows users may need to escape the double-quotes, like so:
+[source,bash,indent=0]
+----
+    $ curl -i -X POST -H "Accept:application/json" -H "Content-Type:application/json" localhost:8083/connectors/ -d '{ \"name\": \"inventory-connector\", \"config\": { \"connector.class\": \"io.debezium.connector.mysql.MySqlConnector\", \"tasks.max\": \"1\", \"database.hostname\": \"mysql\", \"database.port\": \"3306\", \"database.user\": \"debezium\", \"database.password\": \"dbz\", \"database.server.id\": \"184054\", \"database.server.name\": \"dbserver1\", \"database.whitelist\": \"inventory\", \"database.history.kafka.bootstrap.servers\": \"kafka:9092\", \"database.history.kafka.topic\": \"dbhistory.inventory\" } }'
+----
+to avoid this error:
+[source,json,indent=0,subs="attributes"]
+----
+{"error_code":500,"message":"Unexpected character ('n' (code 110)): was expecting double-quote to start field name\n at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 4]"}
+----
+====
+
 This command uses the Kafka Connect service's RESTful API to submit a `POST` request against `/connectors` resource with a JSON document that describes our new connector. Here's the same JSON message in a more readable format:
 
 [source,json,indent=0]


### PR DESCRIPTION
Apparently you need to escape the double quotes in the json body of the request on Windows.