### PR TITLE
DBZ-966 Describe snapshot.delay.ms property

### DIFF
--- a/docs/connectors/mongodb.asciidoc
+++ b/docs/connectors/mongodb.asciidoc
@@ -647,6 +647,12 @@ The following configuration properties are _required_ unless a default value is 
 When `true` the delete operations are represented by a delete event and a subsequent tombstone event. When `false` only a delete event is sent. +
 Emitting the tombstone event (the default behavior) allows Kafka to completely delete all events pertaining to the given key once the source record got deleted.
 
+|`snapshot.delay.ms` +
+0.9.0 and later
+|
+|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
+Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+
 |=======================
 
 

--- a/docs/connectors/oracle.asciidoc
+++ b/docs/connectors/oracle.asciidoc
@@ -934,4 +934,10 @@ Disabled by default.
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
+|`snapshot.delay.ms` +
+0.9.0 and later
+|
+|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
+Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+
 |=======================

--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -1421,6 +1421,12 @@ This setting can improve connector performance significantly if there are freque
 have TOASTed data that are rarely part of these updates. However, it is possible for the in-memory schema to
 become outdated if TOASTable columns are dropped from the table.
 
+|`snapshot.delay.ms` +
+0.9.0 and later
+|
+|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
+Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+
 |=======================
 
 The connector also supports _pass-through_ configuration properties that are used when creating the Kafka producer and consumer.

--- a/docs/connectors/sqlserver.asciidoc
+++ b/docs/connectors/sqlserver.asciidoc
@@ -464,6 +464,12 @@ Disabled by default.
 |Controls the naming of the topic to which heartbeat messages are sent. +
 The topic is named according to the pattern `<heartbeat.topics.prefix>.<server.name>`.
 
+|`snapshot.delay.ms` +
+0.9.0 and later
+|
+|An interval in milli-seconds that the connector should wait before taking a snapshot after starting up; +
+Can be used to avoid snapshot interruptions when starting multiple connectors in a cluster, which may cause re-balancing of connectors.
+
 |=======================
 
 The connector also supports _pass-through_ configuration properties that are used when creating the Kafka producer and consumer. Specifically, all connector configuration properties that begin with the `database.history.producer.` prefix are used (without the prefix) when creating the Kafka producer that writes to the database history, and all those that begin with the prefix `database.history.consumer.` are used (without the prefix) when creating the Kafka consumer that reads the database history upon connector startup.


### PR DESCRIPTION
The property is now exposed in all connectors. Previously it was
available only for MySQL.