### PR TITLE
Add missing `-f` flag to `kafkacat` cmd in the FAQ

### DIFF
--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -202,7 +202,7 @@ Next step is to find out the last offset for the given connector, key under whic
 An example would be:
 
 ```
-$ kafkacat -b localhost -C -t my_connect_offsets -'Partition(%p) %k %s\n'
+$ kafkacat -b localhost -C -t my_connect_offsets -f 'Partition(%p) %k %s\n'
 Partition(11) ["inventory-connector",{"server":"dbserver1"}] {"ts_sec":1530088501,"file":"mysql-bin.000003","pos":817,"row":1,"server_id":223344,"event":2}
 Partition(11) ["inventory-connector",{"server":"dbserver1"}] {"ts_sec":1530168941,"file":"mysql-bin.000004","pos":3261,"row":1,"server_id":223344,"event":2}
 ```


### PR DESCRIPTION
In the FAQ, under the `How to change the offsets of the source database` section, the `kafkacat` command is missing the `f` flag character preceding the format string (it only contains `-` instead of `-f`).