### PR TITLE
DBZ-1029 note about postgres replica identity and 'delete' events

### DIFF
--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -671,6 +671,12 @@ If we look at the `payload` portion, we see a number of differences compared wit
 
 This event gives a consumer all kinds of information that it can use to process the removal of this row.
 
+[WARNING]
+====
+Please pay attention to the tables without PK, any delete messages from such table with REPLICA IDENTITY DEFAULT will have no `before` part (because they have no PK which is the only field for the default identity level) and therefore will be skipped as totally empty.
+To be able to process messages from tables without PK set REPLICA IDENTITY to FULL level.
+====
+
 The PostgreSQL connector's events are designed to work with https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction[Kafka log compaction], which allows for the removal of some older messages as long as at least the most recent message for every key is kept. This allows Kafka to reclaim storage space while ensuring the topic contains a complete dataset and can be used for reloading key-based state.
 
 [[tombstone-events]]


### PR DESCRIPTION
Gentle notation about delete events. All other events working with replica identity levels as expected (and as described in docs)