### PR TITLE
Updated docs to use snapshot.isolation.mode

### DIFF
--- a/docs/connectors/sqlserver.asciidoc
+++ b/docs/connectors/sqlserver.asciidoc
@@ -560,9 +560,17 @@ The following _advanced_ configuration properties have good defaults that will w
 |_initial_
 |A mode for taking an initial snapshot of the structure and optionally data of captured tables. Supported values are _initial_ (will take a snapshot of structure and data of captured tables; useful if topics should be populated with a complete representation of the data from the captured tables) and _initial_schema_only_ (will take a snapshot of the structure of captured tables only; useful if only changes happening from now onwards should be propagated to topics). Once the snapshot is complete, the connector will continue reading change events from the database's redo logs.
 
-|`snapshot.locking.mode`
-|_none_
-|Controls how long the connector locks the monitored tables for snapshot execution. The default is _none_ which means that the connector does not hold any locks for all monitored tables. Using a value of _exclusive_ ensures that the connector holds the exclusive lock (and thus prevents any concurrent reads and updates) for all monitored tables. _snapshot_ mode, in turn, runs the entire snapshot in snapshot transaction isolation level, thus neither table locks nor row-level locks are acquired. Concurrent DDL statements affecting captured tables must not be executed during initial load in snapshot mode to avoid potentially inconsistent schema metadata.
+|`snapshot.isolation.mode`
+|_repeatable_read_
+|Mode to control which transaction isolation level is used and how long the connector locks the monitored tables. There are four possible values `read_uncommitted`, `repeatable_read`, `snapshot`, and `exclusive`. + 
+
+`repeatable_read` In this mode connector will use exclusive locks only during schema snapshot. +
+
+`read_uncommitted` In this mode neither table nor row-level locks are acquired, but connector does not guarantee snapshot consistency. +
+
+`snapshot` In this mode connector runs the initial snapshot in SNAPSHOT isolation level, which guarantees snapshot consistency. In addition, neither table nor row-level locks are held. +
+
+`exclusive` In this mode connector holds the exclusive lock (and thus prevents any reads and updates) for all monitored tables during the entire snapshot duration.
 
 |`poll.interval.ms`
 |`1000`


### PR DESCRIPTION
Removed snapshot.locking.mode and added snapshot.isolation.mode to SQL Server Connector documentation