### PR TITLE
Add documentation to verify if the user have access to cdc table

### DIFF
--- a/docs/connectors/sqlserver.asciidoc
+++ b/docs/connectors/sqlserver.asciidoc
@@ -76,6 +76,17 @@ EXEC sys.sp_cdc_enable_table
 GO
 ----
 
+Verify that the user have access to the cdc table
+[source, sql]
+----
+-- =========
+-- Verify the user of the connector have access, this query should not have empty result
+-- =========
+
+EXEC sys.sp_cdc_help_change_data_capture 
+GO
+----
+
 [[azure]]
 === SQL Server on Azure
 


### PR DESCRIPTION
The connector will not return warning message when the user doesn't have access to the cdc table, so it's better to verify it.