### PR TITLE
Fix link of pulsar binary download in blog post 2019-5-23

### DIFF
--- a/blog/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
+++ b/blog/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
@@ -42,13 +42,13 @@ Version: '5.7.25-log'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL 
 ### Step 2: Start standalone Pulsar service
 Start Pulsar service locally in standalone mode.
 Support for running Debezium connectors in Pulsar IO is introduced in Pulsar 2.3.0.
-Download https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.3.0/apache-pulsar-2.3.0-bin.tar.gz[Pulsar binary of 2.3.0 release] and https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.3.0/connectors/pulsar-io-kafka-connect-adaptor-2.3.0.nar[pulsar-io-kafka-connect-adaptor-2.3.0.nar of 2.3.0 release].
+Download https://archive.apache.org/dist/pulsar/pulsar-2.3.0/apache-pulsar-2.3.0-bin.tar.gz[Pulsar binary of 2.3.0 release] and https://archive.apache.org/dist/pulsar/pulsar-2.3.0/connectors/pulsar-io-kafka-connect-adaptor-2.3.0.nar[pulsar-io-kafka-connect-adaptor-2.3.0.nar of 2.3.0 release].
 In Pulsar, all Pulsar IO connectors are packaged as separate https://medium.com/hashmapinc/nifi-nar-files-explained-14113f7796fd[NAR] files.
 
 [source,bash]
 ----
-$ wget https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.3.0/apache-pulsar-2.3.0-bin.tar.gz -O apache-pulsar-2.3.0-bin.tar.gz
-$ wget https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=pulsar/pulsar-2.3.0/connectors/pulsar-io-kafka-connect-adaptor-2.3.0.nar -O pulsar-io-kafka-connect-adaptor-2.3.0.nar
+$ wget https://archive.apache.org/dist/pulsar/pulsar-2.3.0/apache-pulsar-2.3.0-bin.tar.gz
+$ wget https://archive.apache.org/dist/pulsar/pulsar-2.3.0/connectors/pulsar-io-kafka-connect-adaptor-2.3.0.nar
 $ tar zxf apache-pulsar-2.3.0-bin.tar.gz
 $ cd apache-pulsar-2.3.0
 $ mkdir connectors


### PR DESCRIPTION
There is an issue with the link for pulsar images in the "Step 2: Start standalone Pulsar service" of [this blog](https://debezium.io/blog/2019/05/23/tutorial-using-debezium-connectors-with-apache-pulsar/). 

This was caused by a new release of pulsar between written and post this blog, and we leak a change for it. sorry for this.