### PR TITLE
Postgres connector docs fix on TIMESTAMP mapping

### DIFF
--- a/docs/connectors/postgresql.asciidoc
+++ b/docs/connectors/postgresql.asciidoc
@@ -1010,15 +1010,15 @@ Other than PostgreSQL's `TIMESTAMPTZ` and `TIMETZ` data types (which contain tim
 |`io.debezium.time.MicroTime`
 | Represents the number of microseconds past midnight, and does not include timezone information.
 
-|`TIMESTAMP(1)` , `TIMESTAMP(2)`, `TIMESTAMP(3)`
+|`TIMESTAMP(1)`, `TIMESTAMP(2)`, `TIMESTAMP(3)`
 |`INT64`
 |`io.debezium.time.Timestamp`
 | Represents the number of milliseconds past epoch, and does not include timezone information.
 
-|`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`
+|`TIMESTAMP(4)`, `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
 |`io.debezium.time.MicroTimestamp`
-| Represents the number of milliseconds past epoch, and does not include timezone information.
+| Represents the number of microseconds past epoch, and does not include timezone information.
 
 |=======================
 
@@ -1046,7 +1046,7 @@ When the `time.precision.mode` configuration property is set to `adaptive_time_m
 |`io.debezium.time.Timestamp`
 | Represents the number of milliseconds past epoch, and does not include timezone information.
 
-|`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`
+|`TIMESTAMP(4)` , `TIMESTAMP(5)`, `TIMESTAMP(6)`, `TIMESTAMP`
 |`INT64`
 |`io.debezium.time.MicroTimestamp`
 | Represents the number of microseconds past epoch, and does not include timezone information.


### PR DESCRIPTION
@jpechane, minor doc fix which I noticed while PR reviewing.