### PR TITLE
Added support for right navbar for TOC on large screens

### DIFF
--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -109,12 +109,12 @@ table.tableblock {
 
 /* Render article with full width */
 .doc {
-  max-width: 95%;
+  max-width: 70%;
 }
 
 /* Keep images scaled down a bit */
 .doc .image img {
-  max-width: 600px;
+  max-width: 100%;
 }
 
 @media screen and (min-width: 1200px) {
@@ -140,12 +140,26 @@ table.tableblock {
     top: 148px;
     right: 0;
     color: #222;
+    overflow-y: auto;
+    height: calc(100vh - 8.25rem);
+  }
+
+  .doc.with-toc .toc::-webkit-scrollbar {
+    width: .25rem;
+  }
+
+  .doc.with-toc .toc::-webkit-scrollbar-thumb {
+    background-color: #c1c1c1;
   }
 
   /* Keep title hidden */
   .doc.with-toc .toc > .title {
     display: none;
     height: 0;
+  }
+
+  .doc.with-toc .toc ul {
+    padding-left: 20px;
   }
 
   .doc.with-toc .toc > ul {
@@ -177,22 +191,40 @@ table.tableblock {
     content: '';
     display: inline-block;
     height: 1.15rem;
-    width: 1.35rem;
+    width: 8px;
+    /*
     background: transparent url(../img/caret.svg);
     background-repeat: no-repeat;
     background-size: 50% 50%;
     background-position: 7px 11px;
+    */
   }
 
   .doc.with-toc .toc ul.sectlevel1 > li.expanded:before {
     content: '';
     display: inline-block;
     height: 1.15rem;
-    width: 1.35rem;
+    width: 8px;
+    /*
     background: transparent url(../img/caret.svg);
     background-repeat: no-repeat;
     background-size: 50% 50%;
     background-position: 11px 3px;
     transform: rotate(90deg);
+    */
+  }
+}
+
+@media screen and (min-width: 1350px) {
+  max-width: 75%;
+}
+
+@media screen and (min-width: 1600px) {
+  max-width: 80%;
+}
+
+@media screen and (min-width: 1850px) {
+  .doc {
+    max-width: 72rem;
   }
 }

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -114,15 +114,10 @@ table.tableblock {
 
 /* Keep images scaled down a bit */
 .doc .image img {
-  max-width: 65rem;
+  max-width: 600px;
 }
 
 @media screen and (min-width: 1200px) {
-  /* Set custom width when TOC exists for article contents */
-  .doc.with-toc {
-    max-width: calc(100% - 465px);
-  }
-
   /* by default the TOC won't be shown until the with-toc class is added */
   .doc .toc {
     display: none;
@@ -131,7 +126,7 @@ table.tableblock {
   /* Reposition TOC when exists */
   .doc.with-toc .toc {
     display: block;
-    width: 400px;
+    max-width: 300px;
     height: 100%;
     padding: 5px;
     margin-left: 15px;
@@ -156,8 +151,8 @@ table.tableblock {
   .doc.with-toc .toc > ul {
     padding-inline-start: 0px;
     padding-right: 10px;
-    font-size: .86111rem;
-    line-height: 1.35;
+    font-size: .7rem;
+    line-height: 1.2;
   }
 
   .doc.with-toc .toc > ul ul li {
@@ -181,7 +176,7 @@ table.tableblock {
   .doc.with-toc .toc ul.sectlevel1 > li:before {
     content: '';
     display: inline-block;
-    height: 1.35rem;
+    height: 1.15rem;
     width: 1.35rem;
     background: transparent url(../img/caret.svg);
     background-repeat: no-repeat;
@@ -192,12 +187,12 @@ table.tableblock {
   .doc.with-toc .toc ul.sectlevel1 > li.expanded:before {
     content: '';
     display: inline-block;
-    height: 1.35rem;
+    height: 1.15rem;
     width: 1.35rem;
     background: transparent url(../img/caret.svg);
     background-repeat: no-repeat;
     background-size: 50% 50%;
-    background-position: 11px 5px;
+    background-position: 11px 3px;
     transform: rotate(90deg);
   }
 }

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -106,3 +106,160 @@ table.tableblock {
 .navbar-end > a.navbar-item:hover {
   color: #ffffff;
 }
+
+/** Moves rendered TOC blocks to the right, fixed position for large screen devices */
+
+@media screen and (min-width: 1280px) {
+  .doc {
+    max-width: 55%;
+  }
+
+  .doc .toc {
+    max-width: 400px;
+    padding: 5px;
+    margin-left: 15px;
+    margin-bottom: 15px;
+    background-color: #fafafa;
+    border: 1px solid #e8e8e8;
+    position: fixed;
+    top: 175px;
+    left: 49rem;
+    right: auto;
+    color: #222;
+  }
+
+  .doc .toc > .title {
+    display: none;
+    height: 0;
+  }
+
+  .doc .toc > ul {
+    padding-inline-start: 0px;
+    padding-right: 10px;
+    font-size: .86111rem;
+    line-height: 1.35;
+  }
+
+  .doc .toc > ul ul li {
+    margin-top: .5em;
+  }
+
+  .doc a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .doc a:hover {
+    color: inherit;
+    text-decoration: underline;
+  }
+
+  .doc .toc ul > li {
+    list-style: none;
+  }
+
+  .doc .toc ul.sectlevel1 > li:before {
+    content: '';
+    display: inline-block;
+    height: 1.35rem;
+    width: 1.35rem;
+    background: transparent url(../img/caret.svg);
+    background-repeat: no-repeat;
+    background-size: 50% 50%;
+    background-position: 7px 11px;
+  }
+
+  .doc .toc ul.sectlevel1 > li.expanded:before {
+    content: '';
+    display: inline-block;
+    height: 1.35rem;
+    width: 1.35rem;
+    background: transparent url(../img/caret.svg);
+    background-repeat: no-repeat;
+    background-size: 50% 50%;
+    background-position: 11px 5px;
+    transform: rotate(90deg);
+  }
+}
+
+@media screen and (min-width: 1350px) {
+  .doc .toc {
+    left: 51rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1400px) {
+  .doc .toc {
+    left: 54rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1500px) {
+  .doc {
+    max-width: 60%;
+  }
+
+  .doc .toc {
+    left: 58rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1520px) {
+  .doc .toc {
+    left: 61rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1590px) {
+  .doc .toc {
+    left: 64rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1700px) {
+  .doc {
+    max-width: 65%;
+  }
+
+  .doc .toc {
+    left: 69rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1720px) {
+  .doc .toc {
+    left: 70rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1770px) {
+  .doc .toc {
+    left: 72rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1785px) {
+  .doc .toc {
+    left: 76rem;
+    right: auto;
+  }
+}
+
+@media screen and (min-width: 1920px) {
+  .doc {
+    max-width: 65rem;
+  }
+
+  .doc .toc {
+    left: 83rem;
+    right: auto;
+  }
+}

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -123,14 +123,19 @@ table.tableblock {
     display: none;
   }
 
+  /* makes sure that child sections scroll to the same point as parent section headings */
+  .doc.with-toc h3:not(.discrete) {
+    padding-top: .4rem;
+  }
+
   .doc.with-toc {
-    max-width: 60%;
+    max-width: 30rem;
   }
 
   /* Reposition TOC when exists */
   .doc.with-toc .toc {
     display: block;
-    max-width: 300px;
+    max-width: 100%;
     height: 100%;
     padding: 5px;
     margin-left: 15px;
@@ -142,6 +147,7 @@ table.tableblock {
     border-bottom: none;
     position: fixed;
     top: 148px;
+    left: calc(30rem + 350px);
     right: 0;
     color: #222;
     overflow-y: auto;
@@ -221,18 +227,71 @@ table.tableblock {
 
 @media screen and (min-width: 1350px) {
   .doc.with-toc {
-    max-width: 65%;
+    max-width: 37rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(37rem + 350px);
+  }
+}
+
+@media screen and (min-width: 1450px) {
+  .doc.with-toc {
+    max-width: 44rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(44rem + 350px);
   }
 }
 
 @media screen and (min-width: 1600px) {
   .doc.with-toc {
-    max-width: 70%;
+    max-width: 50rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(50rem + 350px);
   }
 }
 
-@media screen and (min-width: 1900px) {
+@media screen and (min-width: 1675px) {
+  .doc.with-toc {
+    max-width: 55rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(55rem + 350px);
+  }
+}
+
+@media screen and (min-width: 1750px) {
+  .doc.with-toc {
+    max-width: 60rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(60rem + 350px);
+  }
+}
+
+@media screen and (min-width: 1850px) {
+  .doc.with-toc {
+    max-width: 65rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(65rem + 350px);
+  }
+}
+
+@media screen and (min-width: 1920px) {
   .doc.with-toc {
     max-width: 72rem;
+  }
+
+  .doc.with-toc .toc {
+    left: calc(72rem + 350px);
+    right: 0;
   }
 }

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -107,58 +107,78 @@ table.tableblock {
   color: #ffffff;
 }
 
-/** Moves rendered TOC blocks to the right, fixed position for large screen devices */
+/* Render article with full width */
+.doc {
+  max-width: 95%;
+}
 
-@media screen and (min-width: 1280px) {
-  .doc {
-    max-width: 55%;
+/* Keep images scaled down a bit */
+.doc .image img {
+  max-width: 65rem;
+}
+
+@media screen and (min-width: 1200px) {
+  /* Set custom width when TOC exists for article contents */
+  .doc.with-toc {
+    max-width: calc(100% - 465px);
   }
 
+  /* by default the TOC won't be shown until the with-toc class is added */
   .doc .toc {
-    max-width: 400px;
+    display: none;
+  }
+
+  /* Reposition TOC when exists */
+  .doc.with-toc .toc {
+    display: block;
+    width: 400px;
+    height: 100%;
     padding: 5px;
     margin-left: 15px;
     margin-bottom: 15px;
     background-color: #fafafa;
     border: 1px solid #e8e8e8;
+    border-top: none;
+    border-right: none;
+    border-bottom: none;
     position: fixed;
-    top: 175px;
-    left: 49rem;
-    right: auto;
+    top: 148px;
+    right: 0;
     color: #222;
   }
 
-  .doc .toc > .title {
+  /* Keep title hidden */
+  .doc.with-toc .toc > .title {
     display: none;
     height: 0;
   }
 
-  .doc .toc > ul {
+  .doc.with-toc .toc > ul {
     padding-inline-start: 0px;
     padding-right: 10px;
     font-size: .86111rem;
     line-height: 1.35;
   }
 
-  .doc .toc > ul ul li {
+  .doc.with-toc .toc > ul ul li {
     margin-top: .5em;
   }
 
-  .doc a {
+  .doc.with-toc a {
     color: inherit;
     text-decoration: none;
   }
 
-  .doc a:hover {
+  .doc.with-toc a:hover {
     color: inherit;
     text-decoration: underline;
   }
 
-  .doc .toc ul > li {
+  .doc.with-toc .toc ul > li {
     list-style: none;
   }
 
-  .doc .toc ul.sectlevel1 > li:before {
+  .doc.with-toc .toc ul.sectlevel1 > li:before {
     content: '';
     display: inline-block;
     height: 1.35rem;
@@ -169,7 +189,7 @@ table.tableblock {
     background-position: 7px 11px;
   }
 
-  .doc .toc ul.sectlevel1 > li.expanded:before {
+  .doc.with-toc .toc ul.sectlevel1 > li.expanded:before {
     content: '';
     display: inline-block;
     height: 1.35rem;
@@ -179,87 +199,5 @@ table.tableblock {
     background-size: 50% 50%;
     background-position: 11px 5px;
     transform: rotate(90deg);
-  }
-}
-
-@media screen and (min-width: 1350px) {
-  .doc .toc {
-    left: 51rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1400px) {
-  .doc .toc {
-    left: 54rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1500px) {
-  .doc {
-    max-width: 60%;
-  }
-
-  .doc .toc {
-    left: 58rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1520px) {
-  .doc .toc {
-    left: 61rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1590px) {
-  .doc .toc {
-    left: 64rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1700px) {
-  .doc {
-    max-width: 65%;
-  }
-
-  .doc .toc {
-    left: 69rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1720px) {
-  .doc .toc {
-    left: 70rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1770px) {
-  .doc .toc {
-    left: 72rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1785px) {
-  .doc .toc {
-    left: 76rem;
-    right: auto;
-  }
-}
-
-@media screen and (min-width: 1920px) {
-  .doc {
-    max-width: 65rem;
-  }
-
-  .doc .toc {
-    left: 83rem;
-    right: auto;
   }
 }

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -109,7 +109,7 @@ table.tableblock {
 
 /* Render article with full width */
 .doc {
-  max-width: 70%;
+  max-width: 72rem;
 }
 
 /* Keep images scaled down a bit */
@@ -121,6 +121,10 @@ table.tableblock {
   /* by default the TOC won't be shown until the with-toc class is added */
   .doc .toc {
     display: none;
+  }
+
+  .doc.with-toc {
+    max-width: 60%;
   }
 
   /* Reposition TOC when exists */
@@ -216,15 +220,19 @@ table.tableblock {
 }
 
 @media screen and (min-width: 1350px) {
-  max-width: 75%;
+  .doc.with-toc {
+    max-width: 65%;
+  }
 }
 
 @media screen and (min-width: 1600px) {
-  max-width: 80%;
+  .doc.with-toc {
+    max-width: 70%;
+  }
 }
 
-@media screen and (min-width: 1850px) {
-  .doc {
+@media screen and (min-width: 1900px) {
+  .doc.with-toc {
     max-width: 72rem;
   }
 }

--- a/_antora/supplemental_ui/layouts/default.hbs
+++ b/_antora/supplemental_ui/layouts/default.hbs
@@ -6,6 +6,17 @@
 <body class="article">
 {{> header}}
 {{> body}}
+<script>
+    /* Make sure TOC carets are expanded if sub-elements exist */
+    $("#toc ul.sectlevel1 > li").each(function(i,v) {
+      $(this).has("ul").addClass("expanded");
+    });
+
+    $(function() {
+        /* Expands all the documentation submenus */
+        $(".nav-list > .nav-item:not(.is-active) .nav-item-toggle").click();
+    });
+</script>
 {{> footer}}
 </body>
 </html>

--- a/_antora/supplemental_ui/layouts/default.hbs
+++ b/_antora/supplemental_ui/layouts/default.hbs
@@ -21,10 +21,12 @@
         $(".nav-list > .nav-item:not(.is-active) .nav-item-toggle").click();
     });
 
+    /*
     $(".doc.with-toc").each(function(i,v) {
         var tocWidth = $(".toc").width();
         $(this).css("max-width", "calc(100% - " + (tocWidth+75) + "px)");
     });
+    */
 </script>
 {{> footer}}
 </body>

--- a/_antora/supplemental_ui/layouts/default.hbs
+++ b/_antora/supplemental_ui/layouts/default.hbs
@@ -20,6 +20,11 @@
         /* Expands all the documentation submenus */
         $(".nav-list > .nav-item:not(.is-active) .nav-item-toggle").click();
     });
+
+    $(".doc.with-toc").each(function(i,v) {
+        var tocWidth = $(".toc").width();
+        $(this).css("max-width", "calc(100% - " + (tocWidth+75) + "px)");
+    });
 </script>
 {{> footer}}
 </body>

--- a/_antora/supplemental_ui/layouts/default.hbs
+++ b/_antora/supplemental_ui/layouts/default.hbs
@@ -8,6 +8,10 @@
 {{> body}}
 <script>
     /* Make sure TOC carets are expanded if sub-elements exist */
+    $("#toc").each(function(i,v) {
+      $(this).closest('article').addClass('with-toc');
+    });
+
     $("#toc ul.sectlevel1 > li").each(function(i,v) {
       $(this).has("ul").addClass("expanded");
     });

--- a/_antora/supplemental_ui/partials/head-styles.hbs
+++ b/_antora/supplemental_ui/partials/head-styles.hbs
@@ -3,9 +3,3 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/highlightjs-dark.css">
 <link rel="stylesheet" href="https://static.jboss.org/css/rhbar.css">
 <script src="/cache/static.jboss.org/theme/js/libs/jquery/jquery-1.9.1.js"></script>
-<script>
-    $().ready(function() {
-        /* Expands all the documentation submenus */
-        $(".nav-list > .nav-item:not(.is-active) .nav-item-toggle").click();
-    });
-</script>

--- a/_antora/supplemental_ui/partials/head-styles.hbs
+++ b/_antora/supplemental_ui/partials/head-styles.hbs
@@ -2,4 +2,4 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/debezium-antora.css">
 <link rel="stylesheet" href="{{uiRootPath}}/css/highlightjs-dark.css">
 <link rel="stylesheet" href="https://static.jboss.org/css/rhbar.css">
-<script src="/cache/static.jboss.org/theme/js/libs/jquery/jquery-1.9.1.js"></script>
+<script src="//static.jboss.org/theme/js/libs/jquery/jquery-1.9.1.js"></script>


### PR DESCRIPTION
This renders documentation pages with a TOC section in a right navigational bar that is responsive based on the screen size.  On tablet and mobile devices, the TOC continues to be rendered at the top of the asciidoc page like it always has.