### PR TITLE
Adding a link to my recent Kafka Summit presentation slides

### DIFF
--- a/documentation/online-resources.asciidoc
+++ b/documentation/online-resources.asciidoc
@@ -13,6 +13,7 @@ Thanks!
 
 == Presentations and Session Recordings
 
+* https://speakerdeck.com/jbfletch/using-kafka-to-discover-events-hidden-in-your-database["Using Kafka to Discover Events Hidden in your Database"] by Anna McDonald; Kafka Summit San Francisco 2019
 * https://www.infoq.com/news/2019/04/change-data-capture-debezium/["Creating Events from Databases Using Change Data Capture: Gunnar Morling at MicroXchg Berlin"] by Jan Stenberg; a session report from MicroXchg
 * https://developers.redhat.com/videos/youtube/QYbXDp4Vu-8/["Change Data Streaming Patterns for Microservices With Debezium"] by Gunnar Morling; 30 min webinar with live demo, February 2019
 * https://www.slideshare.net/MikeFowler28/migrating-with-debezium["Migrating with Debezium"] by Mike Fowler; London PostgreSQL Meetup, January 2019


### PR DESCRIPTION
I used Debezium in my example scenario in my recent Kafka Summit presentation. @gunnarmorling asked if I would open a PR to add a link to my slides. 