### PR TITLE
DBZ-1466 Add author mode support for locally building

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,10 +90,28 @@ Next, at the command line of that container run the following command:
 
 This cleans up any previously-generated files in the `_site` directory, (re)generates the files for the website, and runs a local webserver to access the site by pointing your browser to [http://localhost:4242]().
 
+Note: With documentation maintained in the main Debezium code repository you may want to edit documentation locally and review how it renders prior to committing changes.  In order to use author mode, two things must be done:
+
+1. The docker container must have an additional volume mapped that points to the main Debezium repository that you've checked out locally.  In this example, we've checked out the https://github.com/debezium/debezium repository to `~/github/debezium`.  So in order to map that directory as a volume on the docker container, you will additionally need to provide the argument `-v ~/github/debezium:/debezium` when starting the container.  Below is an example of how it should look:
+
+        $ docker run -it --rm -p 4242:4242 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site -v ~/github/debezium:/debezium debezium/awestruct bash
+        
+      When inside the docker container, you should notice a `/debezium` directory now exists and its contents is that of the checked out repository.  In the event you do not see a `/debezium` directory or that its contents are empty or incorrect, please review how you mapped the volume above.
+      
+2. By default the rake command uses the remote repository checkout method, which means any changes locally that are staged and uncommitted are not going to be included.  In order to activate author mode, the `author` command line argument should be passed to rake, as shown below:
+
+        /site$ rake clean author preview
+        
+      You want to make sure that you see the following output that confirms its using author-mode.  
+      
+        Generating Antora documentation using configuration: playbook_author.yml
+        
+      If it reports that its using `playbook.yml` instead, then author mode was not properly requested and you should check how you invoked rake.                     
+
 Note: If you're running Docker on Windows or OS X, you must use [port forwarding](https://debezium.io/docs/docker#port-forwarding) so that requests get forwarded properly to the Docker host virtual machine. For example, to port forward when using a Vagrant based VM (virtualbox, etc), you can port forward the `4242` port easily like this:
 
 
-    vagrant ssh -- -vnNTL *:4242:$DOCKER_HOST_IP:4242
+    vagrant ssh -- -vnNTL *:4242:$DOCKER_HOST_IP:4242    
 
 #### Changing the source
 
@@ -266,6 +284,8 @@ Documentation for Debezium is now split between this repository and the [main co
 All of the source files for the site's [docs](https://debezium.io/docs/) are in the `docs` directory, which is structured identically to the URLs of the site (although the source files are _indexified_ as described above). Most of the time you will simply edit one of the existing files. If you want to add a new file, however, be sure that it is referenced in the [docs](https://debezium.io/docs/) table of contents defined in the `_partials/leftcol-doc.html.haml` file.
 
 All of the source files for the site's [version-specific documentation](https://debezium.io/documentation/debezium) are in the main codebase repository.  Please see [DOCUMENTATION.md](http://www.github.com/debezium/debezium/tree/master/DOCUMENTATION.md) in the main codebase repository for details about Antora and how the documentation should be updated.
+
+Note: There are two Antora playbook configuration files used by this repository, `playbook.yml` and `playbook_author.yml`.  It is important that these two files be kept in sync and the only difference between them should be `content.sources[0].url` which controls how each playbook obtains a reference to the Debezium main code repository.  
 
 #### Update the front page
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,11 +279,7 @@ Be sure when a new major/minor release is added that a new `docs/<major>.</minor
 
 #### Edit documentation
 
-Documentation for Debezium is now split between this repository and the [main codebase](https://www.github.com/debezium/debezium.git) repository.  
-
-All of the source files for the site's [docs](https://debezium.io/docs/) are in the `docs` directory, which is structured identically to the URLs of the site (although the source files are _indexified_ as described above). Most of the time you will simply edit one of the existing files. If you want to add a new file, however, be sure that it is referenced in the [docs](https://debezium.io/docs/) table of contents defined in the `_partials/leftcol-doc.html.haml` file.
-
-All of the source files for the site's [version-specific documentation](https://debezium.io/documentation/debezium) are in the main codebase repository.  Please see [DOCUMENTATION.md](http://www.github.com/debezium/debezium/tree/master/DOCUMENTATION.md) in the main codebase repository for details about Antora and how the documentation should be updated.
+Documentation for Debezium is now split between this repository and the [main codebase](https://www.github.com/debezium/debezium.git) repository.  Please see [DOCUMENTATION.md](http://www.github.com/debezium/debezium/tree/master/DOCUMENTATION.md) in the main codebase repository for details about Antora and how the documentation should be updated.
 
 Note: There are two Antora playbook configuration files used by this repository, `playbook.yml` and `playbook_author.yml`.  It is important that these two files be kept in sync and the only difference between them should be `content.sources[0].url` which controls how each playbook obtains a reference to the Debezium main code repository.  
 

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,7 @@
 
 $use_bundle_exec = true
 $awestruct_cmd = nil
+$antora_config = "playbook.yml"
 task :default => :preview
 
 desc 'Setup the environment to run Awestruct'
@@ -170,9 +171,15 @@ task :check => :init do
   system 'sed -i "/.LOG.debug .inherit_front_matter_from for/d" vendor/bundle/ruby/2.3.0/gems/awestruct-0.5.7/lib/awestruct/page.rb'
 end
 
+desc 'Configures Antora build process to use authoring mode, allowing changes to documentation files locally without needing to push changes to github'
+task :author => :check do
+  $antora_config = "playbook_author.yml"
+end
+
 # Execute Antora
 def run_antora()
-  if system "antora playbook.yml"
+  puts "Generating Antora documentation using configuration: #{$antora_config}"
+  if system "antora #{$antora_config}"
     puts "Antora documentation created"
   else
     puts "Antora failed"

--- a/playbook_author.yml
+++ b/playbook_author.yml
@@ -1,0 +1,30 @@
+site:
+  title: Debezium Documentation
+  # the 404, site-map, and canonical urls are only generated when a url is defined
+  url: https://www.debezium.io/documentation
+  start_page: reference::index.adoc
+
+content:
+  sources:
+    - url: /debezium
+      start_path: documentation
+      branches:
+        # The development docs branch has been updated to be called '1.0'.
+        # We should add a 0.10 branch and expose that version docs from there.  Until then, use 0.10.0.Final tag.
+        # - 'development_docs'
+        - 'master'
+        - '0.9'
+        - '0.10'
+
+ui:
+  bundle:
+    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/master/raw/build/ui-bundle.zip?job=bundle-stable
+    snapshot: true
+  supplemental_files: /site/_antora/supplemental_ui
+  output_dir: debezium-antora
+
+runtime:
+  fetch: true
+
+output:
+  dir: /site/_site/documentation


### PR DESCRIPTION
https://issues.jboss.org/browse/DBZ-1466

In order to use author mode, two things will be necessary:

1. Start docker mapping a local checked out copy of the Debezium main code repository as a volume using the name `/debezium`, e.g. `-v <local_path>:/debezium`
2. When running rake, also provide it with the `author` task, e.g. `rake clean author preview`.