### PR TITLE
DBZ-1668 Documentation rendering enhancements

### DIFF
--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -29,8 +29,71 @@ table.tableblock {
   border-radius: 3px;
 }
 
+table.tableblock, th.tableblock, td.tableblock {
+  border: 0 solid #e1e1e1;
+}
+
 .tableblock th.tableblock {
   font-weight: bold;
+}
+
+table.frame-all {
+  border-width: 1px;
+}
+
+table.grid-all th.tableblock, table.grid-all td.tableblock {
+  border-width: 0 1px 1px 0;
+}
+
+table.tableblock thead,
+table.tableblock tfoot {
+  background: #f0f0f0;
+  font-weight: bold;
+}
+
+.doc .table-scroll-wrapper {
+  margin-bottom: 2rem;
+  overflow-x: auto;
+}
+
+.doc .table-scroll-wrapper table.tableblock {
+  margin-bottom: 0px;
+}
+
+/**
+ * For older documentation version we are not removing the footer designation so this
+ * is designed to help migrate old documentation to be as close to the new stuff
+ * as possible.
+ *
+ * todo: once the 1.1 tag has been updated to include this commit, we can remove the 1.1 designation
+ */
+body.version-0-9 table.tableblock tfoot,
+body.version-0-10 table.tableblock tfoot,
+body.version-1-0 table.tableblock tfoot,
+body.version-1-1 table.tableblock tfoot {
+  background: #fff;
+  font-weight: 400;
+}
+
+table.tableblock tr:nth-of-type(even) {
+  background: #f8f8f7;
+}
+
+table.tableblock tr:nth-of-type(odd) {
+  background: inherit;
+}
+
+/**
+ * For older documentation version we are not stripping the table background colors.
+ * This is used to keep old versions of the documentation aligned with this fact.
+ *
+ * todo: once the 1.1 tag has been updated to include this commit, we can remove the 1.1 designation
+ */
+body.version-0-9 table.tableblock tr:nth-of-type(even),
+body.version-0-10 table.tableblock tr:nth-of-type(even),
+body.version-1-0 table.tableblock tr:nth-of-type(even),
+body.version-1-1 table.tableblock tr:nth-of-type(even) {
+  background: inherit;
 }
 
 .nav {
@@ -56,6 +119,7 @@ table.tableblock {
 
 .toolbar {
   top: 5.722rem;
+  z-index: 5;
 }
 
 #rhbar {
@@ -91,6 +155,10 @@ table.tableblock {
   .page-versions-container {
     display: inline-flex;
   }
+
+  .nav-container {
+    font-size: .8rem;
+  }
 }
 
 .page-versions {
@@ -107,51 +175,241 @@ table.tableblock {
   color: #ffffff;
 }
 
+/* control article width relative to viewport */
+#article-wrapper {
+  width: 100%;
+}
+
 /* Render article with full width */
 .doc {
-  max-width: 72rem;
+  max-width: 100%;
 }
 
 /* Keep images scaled down a bit */
 .doc .image img {
-  max-width: 100%;
+  max-width: 1200px;
 }
-
-/*
-.page-versions .versions-menu-select {
-    display: none;
-}
-
-.page-versions.is-active .versions-menu-current {
-    display: none;
-}
-
-.page-versions.is-active .versions-menu-select {
-    display: inline-block;
-}
-*/
 
 .page-versions.is-active .version.is-current {
-    display: block;
+  display: block;
 }
 
 .page-versions .version-menu {
-    border: 1px solid #ccc;
-    padding: .15rem .5rem .5rem;
-    top: -5px;
-    left: 8px;
-    width: 75%;
-    z-index: 10;
+  border: 1px solid #ccc;
+  padding: .15rem .5rem .5rem;
+  top: -5px;
+  left: 8px;
+  width: 100%;
+  z-index: 10;
 }
 
-.doc a, .doc.with-toc a {
-    color: #1565c0;
+/* by default the toc-rightbar is not shown */
+#toc-rightbar {
+  display: none;
+}
+
+.article-grid {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+}
+
+.article-grid .article-cell1 {
+  display: table-cell;
+  overflow-x: auto;
+}
+
+.article-grid .article-cell2 {
+  display: table-cell;
+  /* by default article right cell not visible */
+  width: 0%;
+}
+
+.doc .dlist > dl {
+  margin-block-end: 0px;
+}
+
+.doc .exampleblock {
+  margin: 0px;
+}
+
+.doc .exampleblock .title {
+  margin: 1rem 0 0;
+}
+
+.doc .exampleblock .content {
+  border: 2px solid #5d5d5d;
+  border-radius: .15rem;
+}
+
+strong {
+  font-weight: 600;
+}
+
+.doc .exampleblock .title,
+.doc .imageblock .title,
+.doc .literalblock .title,
+.doc .listingblock .title,
+.doc .openblock .title,
+.doc .tableblock .caption {
+  color: #ba3c23;
+}
+
+.doc p code {
+  background: #e8e8e8;
+}
+
+.doc .tableblock p code {
+  background: inherit;
+}
+
+/* Custom Highlight JS styles */
+
+.highlightjs .language-xml .hljs-tag {
+  color: #e6e87c;
+}
+
+.highlightjs .language-xml .hljs-name {
+  color: #e6e87c;
+}
+
+.highlightjs .language-xml.hljs {
+  color: #fff;
+}
+
+.highlightjs .language-java .hljs-comment {
+  color: #86c786;
+}
+
+.highlightjs .language-java .hljs-doctag {
+  color: #86c786;
+  font-weight: bold;
+}
+
+.highlightjs .language-java .hljs-keyword {
+  color: #d88;
+}
+
+.highlightjs .language-java .hljs-title {
+  color: white;
+}
+
+.highlightjs .language-java .hljs-number {
+  color: #9dc3ea;
+}
+
+.highlightjs .language-java.hljs {
+  color: #fff;
+}
+
+.highlightjs .language-java .hljs-string {
+  color: #6bcc24;
+}
+
+.highlightjs .language-java .hljs-meta {
+  color: #e6e87c;
+}
+
+@media screen and (min-width: 1200px) {
+  /* Hides the original ToC contents on screens larger than 1200px as will be rendered in #toc-rightbar */
+  .main.with-toc .article-cell1 #toc {
+    display: none;
+  }
+
+  .main.with-toc .article-grid .doc {
+    margin-right: 4rem;
+  }
+
+  /* For screens larger than 1200px, configure the toc-rightbar */
+  #toc-rightbar {
+    position: fixed;
+    top: 148px;
+    right: 0px;
+    left: 86%;
+    height: 100%;
+    background-color: #fafafa;
+    height: calc(100vh - 8.25rem);
+    padding: 5px;
+    overflow-y: auto;
+    z-index: 2;
+    border: none;
+    border-left: 1px solid #e8e8e8;
+    border-top: 1px solid #e8e8e8;
+  }
+
+  /* Set by default.hbs if page contains a toc */
+  .main.with-toc #toc-rightbar {
+    display: block;
+  }
+
+  .main.with-toc .article-cell2 {
+    width: 14%;
+  }
+
+  /* Various Right Bar ToC styles */
+  #toc-rightbar .toc {
+    display: block;
+    color: #222;
+    height: 100%;
+  }
+
+  #toc-rightbar .toc::-webkit-scrollbar {
+    widtH: .25rem;
+  }
+
+  #toc-rightbar .toc::-webkit-scrollbar-thumb {
+    background-color: #c1c1c1;
+  }
+
+  /* Keep title hidden */
+  #toc-rightbar .toc > .title {
+    display: none;
+    height: 0;
+  }
+
+  #toc-rightbar .toc ul {
+    padding-left: 20px;
+  }
+
+  #toc-rightbar .toc > ul {
+    padding-inline-start: 0px;
+    padding-right: 10px;
+    font-size: .7rem;
+    line-height: 1.2;
+    margin-block-start: 0px;
+  }
+
+  #toc-rightbar .toc > ul ul li {
+    margin-top: .5em;
+  }
+
+  #toc-rightbar a {
+    color: inherit;
     text-decoration: none;
-}
+  }
 
-.doc a:hover, .doc.with-toc a:hover {
-    color: #104d92;
+  #toc-rightbar a:hover {
+    color: inherit;
     text-decoration: underline;
+  }
+
+  #toc-rightbar .toc ul > li {
+    list-style: none;
+  }
+
+  #toc-rightbar .toc ul.sectlevel1 > li:before {
+    content: '';
+    display: inline-block;
+    height: 1.15rem;
+    width: 8px;
+  }
+
+  #toc-rightbar .toc ul.sectlevel1 > li.expanded:before {
+    content: '';
+    display: inline-block;
+    height: 1.15rem;
+    width: 8px;
+  }
 }
 
 @media screen and (min-width: 1200px) {
@@ -163,173 +421,6 @@ table.tableblock {
   /* makes sure that child sections scroll to the same point as parent section headings */
   .doc.with-toc h3:not(.discrete) {
     padding-top: .4rem;
-  }
-
-  .doc.with-toc {
-    max-width: 30rem;
-  }
-
-  /* Reposition TOC when exists */
-  .doc.with-toc .toc {
-    display: block;
-    max-width: 100%;
-    height: 100%;
-    padding: 5px;
-    margin-left: 15px;
-    margin-bottom: 15px;
-    background-color: #fafafa;
-    border: 1px solid #e8e8e8;
-    border-top: none;
-    border-right: none;
-    border-bottom: none;
-    position: fixed;
-    top: 148px;
-    left: calc(30rem + 350px);
-    right: 0;
-    color: #222;
-    overflow-y: auto;
-    height: calc(100vh - 8.25rem);
-  }
-
-  .doc.with-toc .toc::-webkit-scrollbar {
-    width: .25rem;
-  }
-
-  .doc.with-toc .toc::-webkit-scrollbar-thumb {
-    background-color: #c1c1c1;
-  }
-
-  /* Keep title hidden */
-  .doc.with-toc .toc > .title {
-    display: none;
-    height: 0;
-  }
-
-  .doc.with-toc .toc ul {
-    padding-left: 20px;
-  }
-
-  .doc.with-toc .toc > ul {
-    padding-inline-start: 0px;
-    padding-right: 10px;
-    font-size: .7rem;
-    line-height: 1.2;
-  }
-
-  .doc.with-toc .toc > ul ul li {
-    margin-top: .5em;
-  }
-
-  .doc.with-toc #toc a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .doc.with-toc #toc a:hover {
-    color: inherit;
-    text-decoration: underline;
-  }
-
-  .doc.with-toc .toc ul > li {
-    list-style: none;
-  }
-
-  .doc.with-toc .toc ul.sectlevel1 > li:before {
-    content: '';
-    display: inline-block;
-    height: 1.15rem;
-    width: 8px;
-    /*
-    background: transparent url(../img/caret.svg);
-    background-repeat: no-repeat;
-    background-size: 50% 50%;
-    background-position: 7px 11px;
-    */
-  }
-
-  .doc.with-toc .toc ul.sectlevel1 > li.expanded:before {
-    content: '';
-    display: inline-block;
-    height: 1.15rem;
-    width: 8px;
-    /*
-    background: transparent url(../img/caret.svg);
-    background-repeat: no-repeat;
-    background-size: 50% 50%;
-    background-position: 11px 3px;
-    transform: rotate(90deg);
-    */
-  }
-}
-
-@media screen and (min-width: 1350px) {
-  .doc.with-toc {
-    max-width: 37rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(37rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1450px) {
-  .doc.with-toc {
-    max-width: 44rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(44rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1600px) {
-  .doc.with-toc {
-    max-width: 50rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(50rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1675px) {
-  .doc.with-toc {
-    max-width: 55rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(55rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1750px) {
-  .doc.with-toc {
-    max-width: 60rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(60rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1850px) {
-  .doc.with-toc {
-    max-width: 65rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(65rem + 350px);
-  }
-}
-
-@media screen and (min-width: 1920px) {
-  .doc.with-toc {
-    max-width: 72rem;
-  }
-
-  .doc.with-toc .toc {
-    left: calc(72rem + 350px);
-    right: 0;
   }
 }
 

--- a/_antora/supplemental_ui/js/jquery.ba-floatingscrollbar.js
+++ b/_antora/supplemental_ui/js/jquery.ba-floatingscrollbar.js
@@ -1,0 +1,144 @@
+/*!
+ * jQuery Floating Scrollbar - v0.3 - 02/27/2011
+ * http://benalman.com/
+ *
+ * Copyright (c) 2011 "Cowboy" Ben Alman
+ * Dual licensed under the MIT and GPL licenses.
+ * http://benalman.com/about/license/
+ */
+
+(function($){
+  var // A few reused jQuery objects.
+      win = $(this),
+      html = $('html'),
+
+      // All the elements being monitored.
+      elems = $([]),
+
+      // The current element.
+      current,
+
+      // The previous current element.
+      previous,
+
+      // Create the floating scrollbar.
+      scroller = $('<div id="floating-scrollbar"><div/></div>'),
+      scrollerInner = scroller.children();
+
+  // Initialize the floating scrollbar.
+  scroller
+    .hide()
+    .css({
+      position: 'fixed',
+      bottom: 0,
+      height: '30px',
+      overflowX: 'auto',
+      overflowY: 'hidden'
+    })
+    .scroll(function() {
+      // If there's a current element, set its scroll appropriately.
+      current && current.scrollLeft(scroller.scrollLeft())
+    });
+
+  scrollerInner.css({
+    border: '1px solid #fff',
+    opacity: 0.01
+  });
+
+  // Call on elements to monitor their position and scrollness. Pass `false` to
+  // stop monitoring those elements.
+  $.fn.floatingScrollbar = function( state ) {
+    if ( state === false ) {
+      // Remove these elements from the list.
+      elems = elems.not(this);
+      // Stop monitoring elements for scroll.
+      this.unbind('scroll', scrollCurrent);
+      if ( !elems.length ) {
+        // No elements remain, so detach scroller and unbind events.
+        scroller.detach();
+        win.unbind('resize scroll', update);
+      }
+    } else if ( this.length ) {
+      // Don't assume the set is non-empty!
+      if ( !elems.length ) {
+        // Adding elements for the first time, so attach scroller and bind
+        // events.
+        scroller.appendTo('body');
+        win.resize(update).scroll(update);
+      }
+      // Add these elements to the list.
+      elems = elems.add(this);
+    }
+    // Update.
+    update();
+    // Make chainable.
+    return this;
+  };
+
+  // Call this to force an update, for instance, if elements were inserted into
+  // the DOM before monitored elements, changing their vertical position.
+  $.floatingScrollbarUpdate = update;
+
+  // Hide or show the floating scrollbar.
+  function setState( state ) {
+    scroller.toggle(!!state);
+  }
+
+  // Sync floating scrollbar if element content is scrolled.
+  function scrollCurrent() {
+    current && scroller.scrollLeft(current.scrollLeft())
+  }
+
+  // This is called on window scroll or resize, or when elements are added or
+  // removed from the internal elems list.
+  function update() {
+    previous = current;
+    current = null;
+
+    // Find the first element whose content is visible, but whose bottom is
+    // below the viewport.
+    elems.each(function(){
+      var elem = $(this),
+          top = elem.offset().top,
+          bottom = top + elem.height(),
+          viewportBottom = win.scrollTop() + win.height(),
+          topOffset = 30;
+
+      if ( top + topOffset < viewportBottom && bottom > viewportBottom ) {
+        current = elem;
+        return false;
+      }
+    });
+
+    // Abort if no elements were found.
+    if ( !current ) { setState(); return; }
+
+    // Test to see if the current element has a scrollbar.
+    var scroll = current.scrollLeft();
+
+    var scrollbarWidth = jQuery(current[0]).find("table")[0].clientWidth - current[0].clientWidth;
+    current.scrollLeft(scroll);
+
+    // Abort if the element doesn't have a scrollbar.
+    if ( scrollbarWidth <= 0 ) { setState(); return; }
+
+    // Show the floating scrollbar.
+    setState(true);
+
+    // Adjust the floating scrollbar as-necessary.
+    scroller
+      .css({
+        left: current.offset().left,
+        width: current[0].clientWidth
+      }).scrollLeft(scroll);
+
+    scrollerInner.width(current[0].offsetWidth + scrollbarWidth);
+
+    // Sync floating scrollbar if element content is scrolled.
+    if ( current !== previous ) {
+      previous && previous.unbind('scroll', scrollCurrent);
+      current.scroll(scrollCurrent);
+    }
+  }
+
+})(jQuery);

--- a/_antora/supplemental_ui/layouts/default.hbs
+++ b/_antora/supplemental_ui/layouts/default.hbs
@@ -21,12 +21,37 @@
         $(".nav-list > .nav-item:not(.is-active) .nav-item-toggle").click();
     });
 
-    /*
-    $(".doc.with-toc").each(function(i,v) {
-        var tocWidth = $(".toc").width();
-        $(this).css("max-width", "calc(100% - " + (tocWidth+75) + "px)");
+    /**
+     * This checks if a "#toc" element exists in the DOM and if so:
+     *
+     *  1. Appends a cloned copy of the #toc node to the #toc-rightbar div.
+     *  2. Forces the #toc-rightbar div to be visible.
+     *  3. Adds the .toc-right class to the #article-wrapper div to restrict the article's overall width.
+     */
+    var $toc = $("#toc");
+    if ( $toc.length ) {
+        $("#toc-rightbar").append($toc.clone());
+        $("body .main").addClass("with-toc");
+    }
+
+    /**
+     * In order to make CSS changes that are backward compatible with old adoc files, this applies a version
+     * style to the body tag so we can use it to differentiate between CSS styles per version if needed,
+     * such as tfoot rows.
+     */
+    var $version = $("body .nav-container").data("version");
+    var $versionClass = "version-" + $version;
+    $versionClass = $versionClass.replace('.','-');
+    $("body").addClass($versionClass);
+
+    /** A CSS trick to wrap long-width tables in a div that can be scrolled on smaller screens */
+    $("table.tableblock").wrap("<div class='table-scroll-wrapper'></div>");
+
+    $(function() {
+        /* apply floating scrollbar to the scroll-wrapper */
+        $(".table-scroll-wrapper").floatingScrollbar();
     });
-    */
+
 </script>
 {{> footer}}
 

--- a/_antora/supplemental_ui/partials/article.hbs
+++ b/_antora/supplemental_ui/partials/article.hbs
@@ -1,0 +1,25 @@
+<div class="article-grid">
+<div class="article-cell1">
+<article class="doc">
+    {{#if (eq page.layout '404')}}
+        <h1 class="page">{{{or page.title 'Page Not Found'}}}</h1>
+        <div class="paragraph">
+            <p>The page you&#8217;re looking for does not exist. It may have been moved.</p>
+        </div>
+        <div class="paragraph">
+            <p>If you arrived on this page by clicking on a link, please notify the owner of the site that the link is broken.
+                If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
+        </div>
+    {{else}}
+        {{#if page.title}}
+            <h1 class="page">{{{page.title}}}</h1>
+        {{/if}}
+        {{{page.contents}}}
+    {{/if}}
+</article>
+</div>
+<div class="article-cell2">
+</div>
+</div>
+
+<div id="toc-rightbar"></div>

--- a/_antora/supplemental_ui/partials/head-styles.hbs
+++ b/_antora/supplemental_ui/partials/head-styles.hbs
@@ -3,3 +3,4 @@
 <link rel="stylesheet" href="{{uiRootPath}}/css/highlightjs-dark.css">
 <link rel="stylesheet" href="https://static.jboss.org/css/rhbar.css">
 <script src="//static.jboss.org/theme/js/libs/jquery/jquery-1.9.1.js"></script>
+<script src="{{uiRootPath}}/js/jquery.ba-floatingscrollbar.js"></script>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1668

This PR has a sibling PR in the main repo, https://github.com/debezium/debezium/pull/1216.  We should make sure that the main repo PR is merged prior to this.  

* Reworked Antora UI
  * ToC is now flush to right of window
  * Documentation content uses responsive layout to maximize render space
  * Removed all obsolete responsive CSS for wider screen widths
* Asciidoc changes
  * Tables are now stripped and rendered with grid orders
  * Table headers now have a darker background color
  * Tables rendered using horizontal scrollbar when overflowing
  * Rendering of other blocks such as listings and examples to be consistent
* HighlightJS changes
  * Improved color rendering for Java and and XML

This PR supersedes https://github.com/debezium/debezium.github.io/pull/401.