### PR TITLE
1.1 prep

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -109,6 +109,8 @@ profiles:
         name: SQL Server
       cassandra:
         name: Cassandra
+      db2:
+        name: Db2
   staging:
     jborg_fonts_url: https://static.jboss.org/theme/fonts
     jborg_images_url: https://static.jboss.org/theme/images
@@ -141,6 +143,8 @@ profiles:
         name: SQL Server
       cassandra:
         name: Cassandra
+      db2:
+        name: Db2
   production:
     minified: .min
     css_minifier: enabled
@@ -176,6 +180,8 @@ profiles:
         name: SQL Server
       cassandra:
         name: Cassandra
+      db2:
+        name: Db2
     deploy:
       host: github_pages
       branch: master

--- a/_data/releases/1.1/1.1.0.Beta1.yml
+++ b/_data/releases/1.1/1.1.0.Beta1.yml
@@ -1,0 +1,8 @@
+date: 2020-02-05
+stable: false
+summary: DB2 Connector preview
+# Since we introduced a new connector mid-way through the series, we must specify the additional ones per release.
+# This should be added to the 1.2/series.yml when that release is made.
+connectors:
+  - db2
+# announcement_url:

--- a/_data/releases/1.1/series.yml
+++ b/_data/releases/1.1/series.yml
@@ -26,3 +26,5 @@ compatibility:
     version: 11g, 12c
   cassandra:
     version: 3.11.4
+  db2:
+    version: 11.5

--- a/_layouts/releases.html.haml
+++ b/_layouts/releases.html.haml
@@ -156,6 +156,9 @@ hide_page_header_title: true
                 - if has_connector('cassandra', series, release)
                   %li
                     %a{:href => "https://repo1.maven.org/maven2/io/debezium/debezium-connector-cassandra/#{release.version}/debezium-connector-cassandra-#{release.version}-plugin.tar.gz"} Cassandra Plug-in
+                - if has_connector('db2', series, release)
+                  %li
+                    %a{:href => "https://repo1.maven.org/maven2/io/debezium/debezium-connector-db2/#{release.version}/debezium-connector-db2-#{release.version}-plugin.tar.gz"} Db2 Plug-in
             .btn-group{:style => "margin-top: 4px;"}
               %a.btn.btn-default{:href => "https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20in%20(#{release.version})%20ORDER%20BY%20updated", :target => "_blank"}
                 Resolved issues&nbsp;&nbsp;&nbsp;

--- a/releases/1.1/release-notes.asciidoc
+++ b/releases/1.1/release-notes.asciidoc
@@ -13,6 +13,81 @@ Release numbers follow http://semver.org[Semantic Versioning].
 
 toc::[]
 
+[[release-1.1.0-beta1]]
+== *Release 1.1.0.Beta1* _(February 5th, 2020)_
+
+See the https://issues.redhat.com/secure/ReleaseNote.jspa?projectId=12317320&version=12344479[complete list of issues].
+
+=== Kafka compatibility
+
+This release has been built against Kafka Connect 2.4.0 and has been tested with version 2.4.0 of the Kafka brokers.
+See the https://kafka.apache.org/documentation/#upgrade[Kafka documentation] for compatibility with other versions of Kafka brokers.
+
+=== Upgrading
+
+Before upgrading the MySQL, MongoDB, PostgreSQL or SQL Server connectors, be sure to check the backward-incompatible changes that have been made since the release you were using.
+
+When you decide to upgrade one of these connectors to 1.1.0.Beta1 from any of the earlier 1.1.x, 1.0.x, 0.10.x, 0.9.x, 0.8.x, 0.7.x, 0.6.x, 0.5.x, 0.4.x, 0.3.x, 0.2.x, or 0.1.x versions,
+first check the upgrading notes for the version you're using.
+Gracefully stop the running connector, remove the old plugin files, install the 1.1.0.Beta1 plugin files, and restart the connector using the same configuration.
+Upon restart, the 1.1.0.Beta1 connectors will continue where the previous connector left off.
+As one might expect, all change events previously written to Kafka by the old connector will not be modified.
+
+If you are using our docker images then do not forget to pull them fresh from Docker registry.
+
+=== Breaking changes
+
+Before updating the DecoderBufs logical decoding plug-in in your Postgres database to this new version (or when pulling the debezium/postgres container image for that new version), it is neccessary to upgrade the Debezium Postgres connector to 1.0.1.Final or 1.1.0.Alpha2 or later (https://issues.jboss.org/browse/DBZ-1052[DBZ-1052]).
+
+The `ExtractNewDocumentState` SMT to be used with the Debezium MongoDB connector will convert `Date` and `Timestamp` fields now into the `org.apache.kafka.connect.data.Timestam`p logical type, clarifying its semantics.
+The schema type itself remains unchanged as `int64`.
+Please note that the resolution of `Timestamp` is seconds as per the semantics of that type in MongoDB. (https://issues.jboss.org/browse/DBZ-1717[DBZ-1717]).
+
+
+=== New Features
+
+* Create a plug-in for DB2 streaming https://issues.jboss.org/browse/DBZ-695[DBZ-695]
+* Add topic routing by field option for New Record State Extraction https://issues.jboss.org/browse/DBZ-1715[DBZ-1715]
+* Generate date(time) field types in the Kafka Connect data structure https://issues.jboss.org/browse/DBZ-1717[DBZ-1717]
+* Publish TX boundary markers on a TX metadata topic https://issues.jboss.org/browse/DBZ-1052[DBZ-1052]
+* Replace connectorName with kafkaTopicPrefix in kafka key/value schema https://issues.jboss.org/browse/DBZ-1763[DBZ-1763]
+
+
+=== Fixes
+
+This release includes the following fixes:
+
+* Connector error after adding a new not null column to table in Postgres https://issues.jboss.org/browse/DBZ-1698[DBZ-1698]
+* MySQL connector doesn't use default value of connector.port https://issues.jboss.org/browse/DBZ-1712[DBZ-1712]
+* Fix broken images in Antora and brush up AsciiDoc  https://issues.jboss.org/browse/DBZ-1725[DBZ-1725]
+* ANTLR parser cannot parse MariaDB Table DDL with TRANSACTIONAL attribute https://issues.jboss.org/browse/DBZ-1733[DBZ-1733]
+* Postgres connector does not support proxied connections https://issues.jboss.org/browse/DBZ-1738[DBZ-1738]
+* GET DIAGNOSTICS statement not parseable https://issues.jboss.org/browse/DBZ-1740[DBZ-1740]
+* Examples use http access to Maven repos which is no longer available https://issues.jboss.org/browse/DBZ-1741[DBZ-1741]
+* MySql password logged out in debug log level https://issues.jboss.org/browse/DBZ-1748[DBZ-1748]
+* Cannot shutdown PostgreSQL if there is an active Debezium connector https://issues.jboss.org/browse/DBZ-1727[DBZ-1727]
+
+
+=== Other changes
+
+This release includes also other changes:
+
+* Add tests for using fallback values with default REPLICA IDENTITY https://issues.jboss.org/browse/DBZ-1158[DBZ-1158]
+* Migrate all attribute name/value pairs to Antora component descriptors https://issues.jboss.org/browse/DBZ-1687[DBZ-1687]
+* Upgrade to Awestruct 0.6.0 https://issues.jboss.org/browse/DBZ-1719[DBZ-1719]
+* Run CI tests for delivered non-connector modules (like Quarkus) https://issues.jboss.org/browse/DBZ-1724[DBZ-1724]
+* Remove overlap of different documentation config files https://issues.jboss.org/browse/DBZ-1729[DBZ-1729]
+* Don't fail upon receiving unkown operation events https://issues.jboss.org/browse/DBZ-1747[DBZ-1747]
+* Provide a method to identify an envelope schema https://issues.jboss.org/browse/DBZ-1751[DBZ-1751]
+* Upgrade to Mongo Java Driver version 3.12.1 https://issues.jboss.org/browse/DBZ-1761[DBZ-1761]
+* Create initial Proposal for DB2 Source Connector https://issues.jboss.org/browse/DBZ-1509[DBZ-1509]
+* Review Pull Request for DB2 Connector https://issues.jboss.org/browse/DBZ-1527[DBZ-1527]
+* Test Set up of the DB2 Test Instance https://issues.jboss.org/browse/DBZ-1556[DBZ-1556]
+* Create Documentation for the DB2 Connector https://issues.jboss.org/browse/DBZ-1557[DBZ-1557]
+* Verify support of all DB2 types https://issues.jboss.org/browse/DBZ-1708[DBZ-1708]
+
+
+
 [[release-1.1.0-alpha1]]
 == *Release 1.1.0.Alpha1* _(January 16th, 2020)_
 


### PR DESCRIPTION
This PR goes in tandem with https://github.com/debezium/debezium/pull/1237.  This adds the needed code to support the DB2 connector from the releases and the tested matrix.  

@jpechane I also added a shell of the `1.1.0.Beta1.yml` which you can update with pertinent 1.1 release details as needed when releasing 1.1.