### PR TITLE
Removing inline styles from images

### DIFF
--- a/blog/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
+++ b/blog/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
@@ -24,10 +24,12 @@ which in our case will convert the record into its JSON representation and submi
 
 The overall architecture looks like so:
 
-[.centered-image.responsive-image]
+[.centered-image]
+====
 ++++
-<img src="/images/debezium-embedded.png" style="max-width:100%; margin-bottom:10px;" class="responsive-image" alt="Debezium Embedded Engine Streaming to Amazon Kinesis">
+<img src="/images/debezium-embedded.png" class="responsive-image" alt="Debezium Embedded Engine Streaming to Amazon Kinesis">
 ++++
+====
 
 Now let's walk through the relevant parts of the code required for that.
 A complete executable example can be found in the https://github.com/debezium/debezium-examples/tree/master/kinesis[debezium-examples] repo on GitHub.

--- a/blog/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
+++ b/blog/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
@@ -32,10 +32,12 @@ In particular this approach isn't prone to exposing intermediary aggregations as
 
 The following picture shows the overall architecture:
 
-[.centered-image.responsive-image]
+[.imageblock.centered-image]
+====
 ++++
-<img src="/images/jpa_aggregations.png" style="max-width:100%; margin-bottom:10px;" class="responsive-image" alt="Streaming Materialized Aggregate Views to Elastisearch">
+<img src="/images/jpa_aggregations.png" class="responsive-image" alt="Streaming Materialized Aggregate Views to Elastisearch">
 ++++
+====
 
 Here the aggregate views are materialized by means of a small extension to http://hibernate.org/orm/[Hibernate ORM],
 which stores the JSON aggregates within the source database

--- a/blog/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
+++ b/blog/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
@@ -6,7 +6,7 @@ gmorling
 Updating external full text search indexes (e.g. https://www.elastic.co/products/elasticsearch[Elasticsearch]) after data changes is a very popular use case for change data capture (CDC).
 
 As we've discussed in a link:/blog/2018/01/17/streaming-to-elasticsearch/[blog post] a while ago,
-the combination of Debezium's CDC source connectors and Confluent's https://docs.confluent.io/current/connect/connect-elasticsearch/docs/index.html[sink connector for Elasticsearch] makes it straight forward to capture data changes in MySQL, Postgres etc. and push them towards Elastisearch in near real-time.
+the combination of Debezium's CDC source connectors and Confluent's https://docs.confluent.io/current/connect/connect-elasticsearch/docs/index.html[sink connector for Elasticsearch] makes it straight forward to capture data changes in MySQL, Postgres etc. and push them towards Elasticsearch in near real-time.
 This results in a 1:1 relationship between tables in the source database and a corresponding search index in Elasticsearch,
 which is perfectly fine for many use cases.
 
@@ -35,7 +35,7 @@ The following picture shows the overall architecture:
 [.imageblock.centered-image]
 ====
 ++++
-<img src="/images/jpa_aggregations.png" class="responsive-image" alt="Streaming Materialized Aggregate Views to Elastisearch">
+<img src="/images/jpa_aggregations.png" class="responsive-image" alt="Streaming Materialized Aggregate Views to Elasticsearch">
 ++++
 ====
 

--- a/blog/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
+++ b/blog/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
@@ -33,7 +33,7 @@ http://yuml.me/diagram/plain/class/edit/%2F%2F Cool Class Diagram, [PurchaseOrde
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cache_invalidation_class_diagram.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Example domain model">
+    <img src="/images/cache_invalidation_class_diagram.png" class="responsive-image" alt="Example domain model">
 </div>
 ++++
 
@@ -178,7 +178,7 @@ The following picture shows the design of this approach:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cache_invalidation_architecture.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Architecture Overview">
+    <img src="/images/cache_invalidation_architecture.png" class="responsive-image" alt="Architecture Overview">
 </div>
 ++++
 
@@ -305,7 +305,7 @@ Accounting for this change, the overall architecture looks like so:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cache_invalidation_architecture_tx_registry.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Architecture Overview with Transaction Registry">
+    <img src="/images/cache_invalidation_architecture_tx_registry.png" class="responsive-image" alt="Architecture Overview with Transaction Registry">
 </div>
 ++++
 

--- a/blog/2018-12-19-debezium-0-9-0-beta2-released.adoc
+++ b/blog/2018-12-19-debezium-0-9-0-beta2-released.adoc
@@ -29,7 +29,7 @@ The following image shows an example of displaying the values in OpenJDK's https
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/monitoring_mission_control.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Monitoring the Debezium SQL Server connector">
+    <img src="/images/monitoring_mission_control.png" class="responsive-image" alt="Monitoring the Debezium SQL Server connector">
 </div>
 ++++
 
@@ -40,7 +40,7 @@ As a bonus, we've also created a Grafana dashboard for visualizing all the relev
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/monitoring_dashboard.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Connector metrics in Grafana">
+    <img src="/images/monitoring_dashboard.png" class="responsive-image" alt="Connector metrics in Grafana">
 </div>
 ++++
 

--- a/blog/2019-02-05-debezium-0-9-0-final-released.adoc
+++ b/blog/2019-02-05-debezium-0-9-0-final-released.adoc
@@ -33,7 +33,7 @@ displaying the SQL Server connector metrics:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/java_mission_control.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Monitoring the Debezium SQL Server connector">
+    <img src="/images/java_mission_control.png" class="responsive-image" alt="Monitoring the Debezium SQL Server connector">
 </div>
 ++++
 

--- a/blog/2019-02-13-debezium-0-9-1-final-released.adoc
+++ b/blog/2019-02-13-debezium-0-9-1-final-released.adoc
@@ -23,7 +23,7 @@ A big thank you to the respective authors these fantastic tools!
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/debezium_shell.gif" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="CLI tools for working with Debezium">
+    <img src="/images/debezium_shell.gif" class="responsive-image" alt="CLI tools for working with Debezium">
 </div>
 ++++
 

--- a/blog/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
+++ b/blog/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
@@ -157,7 +157,7 @@ The overall architecture of the solution can be seen in the following picture:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/outbox_pattern.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Outbox Pattern Overview">
+    <img src="/images/outbox_pattern.png" class="responsive-image" alt="Outbox Pattern Overview">
 </div>
 ++++
 

--- a/blog/2019-03-14-debezium-meets-quarkus.adoc
+++ b/blog/2019-03-14-debezium-meets-quarkus.adoc
@@ -33,7 +33,7 @@ This makes the overall architecture look like so:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/outbox_pattern_quarkus.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Outbox Pattern Overview">
+    <img src="/images/outbox_pattern_quarkus.png" class="responsive-image" alt="Outbox Pattern Overview">
 </div>
 ++++
 

--- a/blog/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
+++ b/blog/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
@@ -58,7 +58,7 @@ $ bin/pulsar standalone
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-1.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="start pulsar standalone]">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-1.png" class="responsive-image" alt="start pulsar standalone]">
 </div>
 ++++
 
@@ -114,7 +114,7 @@ Tables are created automatically in the aforementioned MySQL server. So Debezium
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-2.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="connector start process records">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-2.png" class="responsive-image" alt="connector start process records">
 </div>
 ++++
 
@@ -129,7 +129,7 @@ $ bin/pulsar-admin topics list public/default
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-3.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="list Pulsar topics">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-3.png" class="responsive-image" alt="list Pulsar topics">
 </div>
 ++++
 
@@ -189,7 +189,7 @@ mysql> UPDATE products SET name='1111111111' WHERE id=107;
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-4.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="mysql updates">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-4.png" class="responsive-image" alt="mysql updates">
 </div>
 ++++
 
@@ -197,7 +197,7 @@ In the terminal where you consume products topic, you find that two changes have
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-5.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="table topic stores mysql updates">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-5.png" class="responsive-image" alt="table topic stores mysql updates">
 </div>
 ++++
 
@@ -205,7 +205,7 @@ In the terminal where you consume the offset topic, you find that two offsets ha
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-6.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="offset topic get updated">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-6.png" class="responsive-image" alt="offset topic get updated">
 </div>
 ++++
 
@@ -213,7 +213,7 @@ In the terminal where you local-run the connector, you find two more records hav
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/pulsar_tutorial/pulsar-mysql-7.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="table topic get more records">
+    <img src="/images/pulsar_tutorial/pulsar-mysql-7.png" class="responsive-image" alt="table topic get more records">
 </div>
 ++++
 

--- a/blog/2019-07-08-tutorial-sentry-debezium-container-images.adoc
+++ b/blog/2019-07-08-tutorial-sentry-debezium-container-images.adoc
@@ -124,7 +124,7 @@ As an example how a `RecordTooLarge` exception from the Kafka producer would loo
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/sentry/example-record-too-large-exception.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Sentry Exception example">
+    <img src="/images/sentry/example-record-too-large-exception.png" class="responsive-image" alt="Sentry Exception example">
 </div>
 ++++
 

--- a/blog/2019-07-12-streaming-cassandra-at-wepay-part-1.adoc
+++ b/blog/2019-07-12-streaming-cassandra-at-wepay-part-1.adoc
@@ -22,7 +22,7 @@ Given these challenges, and having built and operated a link:https://wecode.wepa
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cassandra/double-write.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Image showing writer send two distinct writes">
+    <img src="/images/cassandra/double-write.png" class="responsive-image" alt="Image showing writer send two distinct writes">
 </div>
 ++++
 
@@ -32,7 +32,7 @@ The idea is to publish to Kafka every time a write is performed on Cassandra. Th
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cassandra/event-source.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Image showing writes sent to Kafka and then downstream DB">
+    <img src="/images/cassandra/event-source.png" class="responsive-image" alt="Image showing writes sent to Kafka and then downstream DB">
 </div>
 ++++
 
@@ -42,7 +42,7 @@ The idea is to write to Kafka rather than directly writing to Cassandra; and the
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/cassandra/commit-log.png" style="max-width:100%; margin-bottom:20px; margin-top:20px;" class="responsive-image" alt="Image showing commit logs sent to Kafka">
+    <img src="/images/cassandra/commit-log.png" class="responsive-image" alt="Image showing commit logs sent to Kafka">
 </div>
 ++++
 

--- a/blog/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
+++ b/blog/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
@@ -65,7 +65,7 @@ The following image shows the overall solution design, based on the example of a
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_overview.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Auditing With Change Data Capture and Stream Processing">
+    <img src="/images/auditing_overview.png" class="responsive-image" alt="Auditing With Change Data Capture and Stream Processing">
 </div>
 ++++
 
@@ -238,7 +238,7 @@ and it is the message key of transaction metadata events:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_input_messages.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Vegetable and Transaction Metadata Messages">
+    <img src="/images/auditing_input_messages.png" class="responsive-image" alt="Vegetable and Transaction Metadata Messages">
 </div>
 ++++
 
@@ -247,7 +247,7 @@ the `client_date`, `usecase` and `user_name` attributes from the former can be a
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_output_message.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Enriched Vegetable Message">
+    <img src="/images/auditing_output_message.png" class="responsive-image" alt="Enriched Vegetable Message">
 </div>
 ++++
 

--- a/blog/2019-10-08-handling-unchanged-postgres-toast-values.adoc
+++ b/blog/2019-10-08-handling-unchanged-postgres-toast-values.adoc
@@ -12,7 +12,7 @@ https://www.postgresql.org/docs/current/storage-toast.html[TOAST] (The Oversized
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/postgres_toast.jpg" style="max-width:100%; width:40%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="TOAST!">
+    <img src="/images/postgres_toast.jpg" style="width:40%;" class="responsive-image" alt="TOAST!">
 </div>
 ++++
 

--- a/blog/2019-10-22-audit-logs-with-kogito.adoc
+++ b/blog/2019-10-22-audit-logs-with-kogito.adoc
@@ -70,13 +70,13 @@ Kafka topics:
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_kogito-process1.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Vegetable events process definition">
+    <img src="/images/auditing_kogito-process1.png" class="responsive-image" alt="Vegetable events process definition">
 </div>
 ++++
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_kogito-process2.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Transaction context data process definition">
+    <img src="/images/auditing_kogito-process2.png" class="responsive-image" alt="Transaction context data process definition">
 </div>
 ++++
 
@@ -96,7 +96,7 @@ work on them to fix missing data.
 
 ++++
 <div class="imageblock centered-image">
-    <img src="/images/auditing_kogito-ui.png" style="max-width:100%; margin-bottom:10px; margin-top:10px;" class="responsive-image" alt="Admin service UI for fixing missing transaction context data">
+    <img src="/images/auditing_kogito-ui.png" class="responsive-image" alt="Admin service UI for fixing missing transaction context data">
 </div>
 ++++
 

--- a/stylesheets/debezium.less
+++ b/stylesheets/debezium.less
@@ -205,7 +205,14 @@
 .centered-image {
   text-align: center;
   margin: 10px;
+  margin-bottom:25px;
+  margin-top:25px;
 }
+
+img.responsive-image {
+  max-width:100%;
+}
+
 // ******************************************************
 // Anchors near the titles
 // ******************************************************


### PR DESCRIPTION
Hey @Naros, can you check out and merge this one if you don't see any issues? Intention is to get rid the inline CSS (margin etc.) around images. I checked a few pages and it looked good.

All the styling is in CSS now, so that's better. To give some context: the raw HTML is done to assign the "responsive-image" class to images. Ideally that all shouldn't be needed to begin with as AsciiDoctor should make images responsive itself, but for whatever reason it doesn't in our case. Unfortunately, there's also no way to give a class for an AsciiDoctor `image`, hence the fall-back to raw HTML. But I think it's acceptable with this fix here.

Note this should be preferred:

```
[.imageblock.centered-image]
====
++++
<img ...>
++++
====
```

Over 

```
++++
<div class="imageblock centered-image">
    <img ...>
</div>
++++
```

So to minimize usage of raw HTML. The latter form is still used in quite a few places, no need to update, but the former should be used going forward.