### PR TITLE
DBZ-1798 Fix miscellaneous documentation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - rm -rf ./_antora_cache
   - docker ps -a
   - ls -la ./_site/documentation
+  - touch ./_site/.nojekyll
 script: rake travis
 env:
   global:

--- a/Rakefile
+++ b/Rakefile
@@ -200,8 +200,6 @@ def run_awestruct(args)
     augmented_args = "#{args}"
   end
   system "#{$use_bundle_exec ? 'bundle exec ' : ''}awestruct #{augmented_args}"
-  # used to enforce GH pages not to run Jekyll on site contents
-  system "touch _site/.nojekyll"
 end
 
 # A cross-platform means of finding an executable in the $PATH.

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -179,11 +179,6 @@ body.version-1-0 table.tableblock tr:nth-of-type(even) {
   max-width: 100%;
 }
 
-/* Keep images scaled down a bit */
-.doc .image img {
-  max-width: 1200px;
-}
-
 .page-versions.is-active .version.is-current {
   display: block;
 }
@@ -407,6 +402,11 @@ strong {
 }
 
 @media screen and (min-width: 1200px) {
+  /* Images scale based on viewer UI */
+  .doc .image img {
+    max-width: 100%;
+  }
+
   /* by default the TOC won't be shown until the with-toc class is added */
   .doc .toc {
     display: none;
@@ -415,6 +415,13 @@ strong {
   /* makes sure that child sections scroll to the same point as parent section headings */
   .doc.with-toc h3:not(.discrete) {
     padding-top: .4rem;
+  }
+}
+
+@media screen and (min-width: 1600px) {
+  /* Keep images scaled down a bit */
+  .doc .image img {
+    max-width: 1200px;
   }
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1798

In commit 27645e8, I am forcing the Travis CI build step to generate a `.nojekyll` file in the pre-build steps since Awestruct does not copy the `.nojekyll` file from the root of the repository.  This should allow images stored in `/documentation/reference/_images` to be rendered as they'll be published to github pages where-as previously without the `.nojekyll` they were not.

In commit 22248d2, this should resolve the overflow issue when browser window size is smaller than 1600px, forcing the image to respect aspect ratio and resize appropriately based on resolution.