### PR TITLE
DBZ-2031 Add JDBC driver versions to release metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,20 +233,67 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 8.0.13
+    database:
+      versions:
+        - 5.7
+        - 8.0.13
+    driver:
+      versions:
+        - 8.0.13
   mongodb:
-    version: 3.2, 3.4, 4.0
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 3.6
+        - 4.0
+    driver:
+      versions:
+        - 3.11.1
   postgresql:
-    version: 9.6, 10, 11
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+        - 12
+    driver:
+      versions:
+        - 42.2.9
   sqlserver:
-    veresion: 2017
+    database:
+      versions:
+        - 2017
+        - 2019
+    driver:
+      versions:
+        - 7.2.2.jre8
   oracle:
-    version: 11g, 12c   
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1  
+  cassandra:
+    database:
+      versions: 
+        - 3.11.4
+    driver:
+      versions:
+        - 3.5.0         
 ```  
 
 The `summary` attribute describes a brief overview/highlight of changes in this series.
 
-The contents under _compatibility_ are meant to reflect what this version was tested with.  If new compatibility types are added, be sure to update the `_config/site.yml` file accordingly.
+The contents under _compatibility_ are meant to reflect what this version was tested with.
+If new compatibility types are added, be sure to update the `_config/site.yml` file accordingly.
+For non-connector entries, specifying the compatibility-type and its associated version string is sufficient.
+For connector entries, specify the `database -> versions` and `driver -> versions` arrays accordingly.
+
+_Note that since a series.yml file describes a release series and not a specific bugfix release, the contents of the file should reflect what the latest test compatibility is for the most recent release within the series._
+_So as new releases are added to a given series, its important to update the series.yml file with the pertinent connector and driver tested versions_.
 
 The _hidden_ attribute describes whether or not the series should be exposed on the website at all.   In general, when a series is considered legacy/old and no longer relevant, this attribute can be set to _true_ and no reference to this version will be included in the awestruct output.
 

--- a/_data/releases/0.10/series.yml
+++ b/_data/releases/0.10/series.yml
@@ -16,14 +16,50 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 5.7, 8.0.13
+    database:
+      versions:
+        - 5.7
+        - 8.0.13
+    driver:
+      versions:
+        - 8.0.16
   mongodb:
-    version: 3.2, 3.4, 4.0
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 4.0
+    driver:
+      versions:
+        - 3.10.1
   postgresql:
-    version: 9.6, 10, 11
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+    driver:
+      versions:
+        - 42.2.8
   sqlserver:
-    version: 2017
+    database:
+      versions:
+        - 2017
+    driver:
+      versions:
+        - 7.2.2.jre8
   oracle:
-    version: 11g, 12c
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1
   cassandra:
-    version: 3.11.4
+    database:
+      versions:
+        - 3.11.4
+    driver:
+      versions:
+        - 3.5.0

--- a/_data/releases/0.9/series.yml
+++ b/_data/releases/0.9/series.yml
@@ -14,12 +14,43 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 5.7, 8.0.13
+    database:
+      versions:
+        - 5.7
+        - 8.0.13
+    driver:
+      versions:
+        - 8.0.13
   mongodb:
-    version: 3.2, 3.4, 4.0
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 4.0
+    driver:
+      versions:
+        - 3.9.0
   postgresql:
-    version: 9.6, 10, 11
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+    driver:
+      versions:
+        - 42.2.5
   sqlserver:
-    version: 2017
+    database:
+      versions:
+        - 2017
+    driver:
+      versions:
+        - 6.4.0.jre8
   oracle:
-    version: 11g, 12c
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1

--- a/_data/releases/1.0/series.yml
+++ b/_data/releases/1.0/series.yml
@@ -15,14 +15,54 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 5.7, 8.0.13
+    database:
+      versions:
+        - 5.7
+        - 8.0.13
+    driver:
+      versions:
+        - 8.0.16
   mongodb:
-    version: 3.2, 3.4, 3.6, 4.0, 4.2
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 3.6
+        - 4.0
+        - 4.2
+    driver:
+      versions:
+        - 3.11.1
   postgresql:
-    version: 9.6, 10, 11, 12
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+        - 12
+    driver:
+      versions:
+        - 42.2.9
   sqlserver:
-    version: 2017, 2019
+    database:
+      versions:
+        - 2017
+        - 2019
+    driver:
+      versions:
+        - 7.2.2.jre8
   oracle:
-    version: 11g, 12c
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1
   cassandra:
-    version: 3.11.4
+    database:
+      versions:
+        - 3.11.4
+    driver:
+      versions:
+        - 3.5.0

--- a/_data/releases/1.1/series.yml
+++ b/_data/releases/1.1/series.yml
@@ -15,16 +15,61 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 5.7, 8.0.13
+    database:
+      versions:
+        - 5.7
+        - 8.0.13
+    driver:
+      versions:
+        - 8.0.16
   mongodb:
-    version: 3.2, 3.4, 3.6, 4.0, 4.2
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 3.6
+        - 4.0
+        - 4.2
+    driver:
+      versions:
+        - 3.12.2
   postgresql:
-    version: 9.6, 10, 11, 12
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+        - 12
+    driver:
+      versions:
+        - 42.2.9
   sqlserver:
-    version: 2017, 2019
+    database:
+      versions:
+        - 2017
+        - 2019
+    driver:
+      versions:
+        - 7.2.2.jre8
   oracle:
-    version: 11g, 12c
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1
   cassandra:
-    version: 3.11.4
+    database:
+      versions:
+        - 3.11.4
+    driver:
+      versions:
+        - 3.5.0
   db2:
-    version: 11.5
+    database:
+      versions:
+        - 11.5
+    driver:
+      versions:
+        - 11.5.0.0

--- a/_data/releases/1.2/series.yml
+++ b/_data/releases/1.2/series.yml
@@ -16,16 +16,61 @@ compatibility:
   connect:
     version: 1.x, 2.x
   mysql:
-    version: 5.7, 8.0
+    database:
+      versions:
+        - 5.7
+        - 8.0.x
+    driver:
+      versions:
+        - 8.0.16
   mongodb:
-    version: 3.2, 3.4, 3.6, 4.0, 4.2
+    database:
+      versions:
+        - 3.2
+        - 3.4
+        - 3.6
+        - 4.0
+        - 4.2
+    driver:
+      versions:
+        - 3.12.3
   postgresql:
-    version: 9.6, 10, 11, 12
+    database:
+      versions:
+        - 9.6
+        - 10
+        - 11
+        - 12
+    driver:
+      versions:
+        - 42.2.12
   sqlserver:
-    version: 2017, 2019
+    database:
+      versions:
+        - 2017
+        - 2019
+    driver:
+      versions:
+        - 7.2.2.jre8
   oracle:
-    version: 11g, 12c
+    database:
+      versions:
+        - 11g
+        - 12c
+    driver:
+      versions:
+        - 12.2.0.1
   cassandra:
-    version: 3.11.4
+    database:
+      versions:
+        - 3.11.4
+    driver:
+      versions:
+        - 3.5.0
   db2:
-    version: 11.5
+    database:
+      versions:
+        - 11.5
+    driver:
+      versions:
+        - 11.5.0.0

--- a/_layouts/releases.html.haml
+++ b/_layouts/releases.html.haml
@@ -65,7 +65,25 @@ hide_page_header_title: true
       %td= integration["name"]
       %td
         - compatibility = series.compatibility[integration_id]
-        = compatibility.nil? ? 'N/A' : compatibility.version
+        - if !compatibility.nil?
+          - if !compatibility.database.versions.nil? && compatibility.database.versions.any?
+            %span{:class => "test-with-subcategory"}
+              Database:
+            - compatibility.database.versions.each_with_index do |versiondb, index|
+              #{(compatibility.database.versions.size-1) != index ? "#{versiondb}, " : "#{versiondb}"}
+            %br
+          - if !compatibility.driver.versions.nil? && compatibility.driver.versions.any?
+            %span{:class => "test-with-subcategory"}
+              JDBC Driver:
+            - compatibility.driver.versions.each_with_index do |versionjdbc, index|
+              #{(compatibility.driver.versions.size-1) != index ? "#{versionjdbc}, " : "#{versionjdbc}"}
+            %br
+          - if !compatibility.database.versions.nil? && !compatibility.database.versions.any? && !compatibility.driver.versions.nil? && !compatibility.driver.versions.any? && !compatibility.version.nil?
+            = compatibility.version
+          - elsif !compatibility.database.versions.nil? && !compatibility.database.versions.any? && !compatibility.driver.versions.nil? && !compatibility.driver.versions.any?
+            = "N/A"
+        - else
+          = "N/A"
 
 %p
   Not compatible with your requirements?  Have a look at the

--- a/releases/index.html.haml
+++ b/releases/index.html.haml
@@ -38,10 +38,26 @@ title: Debezium Releases Overview
       - active_series.each do |series|
         - compatibility = series.compatibility[integration_id]
         %td
-          - if compatibility == nil
-            N/A
+          - if !compatibility.nil?
+            - if !compatibility.database.versions.nil? && compatibility.database.versions.any?
+              %span{:class => "test-with-subcategory"}
+                Database:
+              - compatibility.database.versions.each_with_index do |versiondb, index|
+                #{(compatibility.database.versions.size-1) != index ? "#{versiondb}, " : "#{versiondb}"}
+              %br
+            - if !compatibility.driver.versions.nil? && compatibility.driver.versions.any?
+              %span{:class => "test-with-subcategory"}
+                JDBC Driver:
+              - compatibility.driver.versions.each_with_index do |versionjdbc, index|
+                #{(compatibility.driver.versions.size-1) != index ? "#{versionjdbc}, " : "#{versionjdbc}"}
+              %br
+            - if !compatibility.database.versions.nil? && !compatibility.database.versions.any? && !compatibility.driver.versions.nil? && !compatibility.driver.versions.any? && !compatibility.version.nil?
+              = compatibility.version
+            - elsif !compatibility.database.versions.nil? && !compatibility.database.versions.any? && !compatibility.driver.versions.nil? && !compatibility.driver.versions.any?
+              = "N/A"
           - else
-            #{compatibility.version}
+            = "N/A"
+
 %h6.table-note
   The Debezium connectors have been tested with the versions of Java, Apache Kafka (Connect), and databases listed above.
   Note that Debezium might also be compatible with other database versions not listed here.

--- a/stylesheets/debezium.less
+++ b/stylesheets/debezium.less
@@ -754,3 +754,9 @@ table.data th {
   background-color: #369;
   color: white;
 }
+
+span.test-with-subcategory {
+  font-size: 13px;
+  font-style: italic;
+  color: #8f8f8f;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2031

This PR modifies the `series.yml` definition so that both database and driver version metadata can be placed in the YAML files in `_data/releases/<major>.<minor>/series.yml` files and rendered on the releases overview and specific release page test matrix tables.