### PR TITLE
DBZ-1951 Introduce banner for development/older versions

### DIFF
--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -304,6 +304,26 @@ strong {
   color: #e6e87c;
 }
 
+div.version-banner {
+    padding: 0.75rem 1.25rem;
+    margin-bottoM: 1rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    margin-top: 25px;
+}
+
+div.version-banner-development {
+    color: #004005;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+}
+
+div.version-banner-outdated {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
 @media screen and (min-width: 1200px) {
   /* Hides the original ToC contents on screens larger than 1200px as will be rendered in #toc-rightbar */
   .main.with-toc .article-cell1 #toc {

--- a/_antora/supplemental_ui/partials/article.hbs
+++ b/_antora/supplemental_ui/partials/article.hbs
@@ -11,6 +11,15 @@
                 If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
         </div>
     {{else}}
+        {{#if (eq page.version 'master')}}
+            {{> banner-development}}
+        {{else}}
+            {{#if (eq page.versions.1.displayVersion page.version)}}
+                {{> banner-current}}
+            {{else}}
+                {{> banner-outdated}}
+            {{/if}}
+        {{/if}}
         {{#if page.title}}
             <h1 class="page">{{{page.title}}}</h1>
         {{/if}}

--- a/_antora/supplemental_ui/partials/banner-current.hbs
+++ b/_antora/supplemental_ui/partials/banner-current.hbs
@@ -1,0 +1,1 @@
+<!-- This partial is a placeholder -->

--- a/_antora/supplemental_ui/partials/banner-development.hbs
+++ b/_antora/supplemental_ui/partials/banner-development.hbs
@@ -1,0 +1,5 @@
+<div class="version-banner version-banner-development">
+    You are viewing documentation for the current development version of Debezium.
+    <br/>
+    If you want to view the latest stable version of this page, please go <a href="{{{relativize page.versions.1.url}}}">here</a>.
+</div>

--- a/_antora/supplemental_ui/partials/banner-outdated.hbs
+++ b/_antora/supplemental_ui/partials/banner-outdated.hbs
@@ -1,0 +1,5 @@
+<div class="version-banner version-banner-outdated">
+    You are viewing documentation for an outdated version of Debezium.
+    <br/>
+    If you want to view the latest stable version of this page, please go <a href="{{{relativize page.versions.1.url}}}">here</a>.
+</div>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1951

So I decided to base the logic on when to apply the version banner because I wanted to see if we can do this without introducing even more steps to the release process for maintaining attributes. Antora maintains an array of versions and we use this array to compare against the version of the page rendered to see whether to apply the "development" or "outdated" banners.  

The banner placement is probably not ideal at the moment since it scrolls with the page content but in order to avoid problems with other rendering concerns, we can't make it static above the breadcrumbs portion of the page since the content that is scrollable is offset by a fixed number of pixels.

I'm open to any feedback or suggestions.