### PR TITLE
Revert "DBZ-1951 Introduce banner for development/older versions"

### DIFF
--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -304,26 +304,6 @@ strong {
   color: #e6e87c;
 }
 
-div.version-banner {
-    padding: 0.75rem 1.25rem;
-    margin-bottoM: 1rem;
-    border: 1px solid transparent;
-    border-radius: 0.25rem;
-    margin-top: 25px;
-}
-
-div.version-banner-development {
-    color: #004005;
-    background-color: #cce5ff;
-    border-color: #b8daff;
-}
-
-div.version-banner-outdated {
-    color: #856404;
-    background-color: #fff3cd;
-    border-color: #ffeeba;
-}
-
 @media screen and (min-width: 1200px) {
   /* Hides the original ToC contents on screens larger than 1200px as will be rendered in #toc-rightbar */
   .main.with-toc .article-cell1 #toc {

--- a/_antora/supplemental_ui/partials/article.hbs
+++ b/_antora/supplemental_ui/partials/article.hbs
@@ -11,15 +11,6 @@
                 If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
         </div>
     {{else}}
-        {{#if (eq page.version 'master')}}
-            {{> banner-development}}
-        {{else}}
-            {{#if (eq page.versions.1.displayVersion page.version)}}
-                {{> banner-current}}
-            {{else}}
-                {{> banner-outdated}}
-            {{/if}}
-        {{/if}}
         {{#if page.title}}
             <h1 class="page">{{{page.title}}}</h1>
         {{/if}}

--- a/_antora/supplemental_ui/partials/banner-current.hbs
+++ b/_antora/supplemental_ui/partials/banner-current.hbs
@@ -1,1 +1,0 @@
-<!-- This partial is a placeholder -->

--- a/_antora/supplemental_ui/partials/banner-development.hbs
+++ b/_antora/supplemental_ui/partials/banner-development.hbs
@@ -1,5 +1,0 @@
-<div class="version-banner version-banner-development">
-    You are viewing documentation for the current development version of Debezium.
-    <br/>
-    If you want to view the latest stable version of this page, please go <a href="{{{relativize page.versions.1.url}}}">here</a>.
-</div>

--- a/_antora/supplemental_ui/partials/banner-outdated.hbs
+++ b/_antora/supplemental_ui/partials/banner-outdated.hbs
@@ -1,5 +1,0 @@
-<div class="version-banner version-banner-outdated">
-    You are viewing documentation for an outdated version of Debezium.
-    <br/>
-    If you want to view the latest stable version of this page, please go <a href="{{{relativize page.versions.1.url}}}">here</a>.
-</div>


### PR DESCRIPTION
Reverts debezium/debezium.github.io#461

Agh, noticed one issue: It uses 1.2 as the current stable, instead of 1.1. Probably an easy fix.