### PR TITLE
DBZ-1951 Rework introduction of banner for development/older versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,6 +320,23 @@ The `summary` describes a brief overview of the changes in this specific release
 
 The `annoncement_url` is the fully qualified URL to the blog post about the release.
 
+##### Update playbook attributes
+
+When a new stable release has been published, be sure to update `playbook.yml` and `playbook_author.yml` files and set the `page-version-current` asciidoc variable to the most recent stable version identified by the `version` attribute from the main repository's `antora.yml` descriptor (see Antora Version in the table below).
+
+At the time of writing the following table illustrates the mappings:
+
+|Branch|Debezium Version|Antora Version|
+|---|---|---|
+|master|1.2.x|master|
+|1.2|1.2.x|1.2|
+|1.1|1.1.x|1.1|
+|1.0|1.0.x|1.0|
+|0.9|0.9.x|0.9|
+
+At the time of writing this, 1.2 has not yet been published as _Final_ and therefore the `page-version-current` asciidoc attribute in the playbook files should reference the Antora Version value of `1.1`.
+Once version 1.2.0.Final has been released, the playbooks should reference `1.2`.
+
 ##### Updating docs hierarchy
 
 Be sure when a new major/minor release is added that a new `docs/<major>.</minor>` directory is created and contains an `index.asciidoc` and `release-notes.asciidoc`.  See prior version directories for examples.

--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -304,6 +304,26 @@ strong {
   color: #e6e87c;
 }
 
+div.version-banner {
+    padding: 0.75rem 1.25rem;
+    margin-bottoM: 1rem;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+    margin-top: 25px;
+}
+
+div.version-banner-development {
+    color: #004005;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+}
+
+div.version-banner-outdated {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
 @media screen and (min-width: 1200px) {
   /* Hides the original ToC contents on screens larger than 1200px as will be rendered in #toc-rightbar */
   .main.with-toc .article-cell1 #toc {

--- a/_antora/supplemental_ui/helpers/gt.js
+++ b/_antora/supplemental_ui/helpers/gt.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (a, b) => a > b

--- a/_antora/supplemental_ui/partials/article.hbs
+++ b/_antora/supplemental_ui/partials/article.hbs
@@ -11,6 +11,7 @@
                 If you typed the URL of this page manually, please double check that you entered the address correctly.</p>
         </div>
     {{else}}
+        {{> banner }}
         {{#if page.title}}
             <h1 class="page">{{{page.title}}}</h1>
         {{/if}}

--- a/_antora/supplemental_ui/partials/banner-current.hbs
+++ b/_antora/supplemental_ui/partials/banner-current.hbs
@@ -1,0 +1,1 @@
+<!-- This partial is a placeholder -->

--- a/_antora/supplemental_ui/partials/banner-development.hbs
+++ b/_antora/supplemental_ui/partials/banner-development.hbs
@@ -1,0 +1,10 @@
+<div class="version-banner version-banner-development">
+    You are viewing documentation for the current development version of Debezium.
+    <br/>
+    {{#each page.versions}}
+        {{#if (eq @root.page.attributes.version-current ./displayVersion)}}
+            If you want to view the latest stable version of this page, please go <a href="{{{relativize ./url}}}">here</a>.
+            {{break}}
+        {{/if}}
+    {{/each}}
+</div>

--- a/_antora/supplemental_ui/partials/banner-outdated.hbs
+++ b/_antora/supplemental_ui/partials/banner-outdated.hbs
@@ -1,0 +1,10 @@
+<div class="version-banner version-banner-outdated">
+    You are viewing documentation for an outdated version of Debezium.
+    <br/>
+    {{#each page.versions}}
+        {{#if (eq @root.page.attributes.version-current ./displayVersion)}}
+            If you want to view the latest stable version of this page, please go <a href="{{{relativize ./url}}}">here</a>.
+            {{break}}
+        {{/if}}
+    {{/each}}
+</div>

--- a/_antora/supplemental_ui/partials/banner.hbs
+++ b/_antora/supplemental_ui/partials/banner.hbs
@@ -1,0 +1,17 @@
+{{!--
+    This partial is responsible for rendering one of 3 banners at the top of each article:
+
+        banner-current.hbs
+        banner-development.hbs
+        banner-outdated.hbs
+--}}
+{{#if (or (eq page.version 'master') (gt page.version page.attributes.version-current))}}
+    {{!-- For antora.yml that references master or a version less than current defined in playbook, add development banner --}}
+    {{> banner-development}}
+{{else if (eq page.version page.attributes.version-current)}}
+    {{!-- For version that equals the current defined in playbook, add current banner --}}
+    {{> banner-current}}
+{{else}}
+    {{!-- For all other scenarios, considered outdated --}}
+    {{> banner-outdated}}
+{{/if}}

--- a/playbook.yml
+++ b/playbook.yml
@@ -37,5 +37,10 @@ asciidoc:
     prodname: 'Debezium'
     context: 'debezium'
     jira-url: 'https://issues.redhat.com'
-    # because of how handlebars templates work with page.attributes, this must be prefixed with "page-"
+    # because of how handlebars templates work with page.attributes, these must be prefixed with "page-"
     page-copyright-year: '2020'
+    # this should be changed every stable release to indicate the most recent stable release.
+    # A version prior to this in the version list will display the banner-development.hbs partial.
+    # A version after this in the version list will display the banner-outdated.hbs partial.
+    # This specific version will display the banner-current.hbs partial.
+    page-version-current: '1.1'

--- a/playbook_author.yml
+++ b/playbook_author.yml
@@ -37,5 +37,10 @@ asciidoc:
     prodname: 'Debezium'
     context: 'debezium'
     jira-url: 'https://issues.redhat.com'
-    # because of how handlebars templates work with page.attributes, this must be prefixed with "page-"
+    # because of how handlebars templates work with page.attributes, these must be prefixed with "page-"
     page-copyright-year: '2020'
+    # this should be changed every stable release to indicate the most recent stable release.
+    # A version prior to this in the version list will display the banner-development.hbs partial.
+    # A version after this in the version list will display the banner-outdated.hbs partial.
+    # This specific version will display the banner-current.hbs partial.
+    page-version-current: '1.1'


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-1951

This is the reworked implementation after being reverted in #463.  This should currently specify that version 1.1 is the current version, master/1.2 are the development iterations, and anything prior to version 1.1 is deemed out-dated.