### PR TITLE
Enable overriding of the documentation context global variable

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -36,7 +36,7 @@ output:
 asciidoc:
   attributes:
     prodname: 'Debezium'
-    context: 'debezium'
+    context@: 'debezium'
     jira-url: 'https://issues.redhat.com'
     # because of how handlebars templates work with page.attributes, these must be prefixed with "page-"
     page-copyright-year: '2020'

--- a/playbook_author.yml
+++ b/playbook_author.yml
@@ -36,7 +36,7 @@ output:
 asciidoc:
   attributes:
     prodname: 'Debezium'
-    context: 'debezium'
+    context@: 'debezium'
     jira-url: 'https://issues.redhat.com'
     # because of how handlebars templates work with page.attributes, these must be prefixed with "page-"
     page-copyright-year: '2020'


### PR DESCRIPTION
This PR is needed for https://github.com/debezium/debezium/pull/1886 so that the documentation overrides for the `context` global variable will work properly for newer versions of the documentation but also so that older versions of the documentation are generated as they always have without warnings of a missing `context` variable.