### PR TITLE
Handle redirect for links in old posts

### DIFF
--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  {% assign theLastVersion = site.data.versions.versions.last %}
+  {% for version in site.data.versions.versions %}
+    {% assign formatedVersion = version | replace: ".", "" %} 
+    {% assign releaseDetails = site.data.releases[formatedVersion] %} 
+    {% if releaseDetails.series.displayed %}
+      {% assign lastVersion = releaseDetails.versions.versions.last %}
+      {% assign formattedLastVersion = lastVersion | replace: ".", "" %}
+      {% assign latestRelease = releaseDetails[formattedLastVersion] %}
+        {% if latestRelease.stable %}
+          {% assign latestStableVersion = version %}
+        {% endif %}
+    {% endif %} 
+  {% endfor %}
+         
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    {% assign redir_url = page.redir_to | replace: "!LATEST_STABLE_VERSION!", latestStableVersion |  replace: "!LATEST_VERSION!", theLastVersion %}
+    <link rel="canonical" href="{{ redir_url }}"/>
+    <meta http-equiv="refresh" content="0;url={{ redir_url }}" />
+  </head>
+
+  <body>
+    <h1>Redirecting...</h1>
+    <a href="{{ redir_url }}">Click here if you are not redirected.<a>
+    <script>location="{{ redir_url }}"</script>
+  </body>
+
+</html>

--- a/_posts/2017-09-25-streaming-to-another-database.adoc
+++ b/_posts/2017-09-25-streaming-to-another-database.adoc
@@ -18,10 +18,13 @@ We will also demonstrate a new functionality that was released with link:2017/09
 == Topology
 The general topology for this scenario is displayed on the following picture:
 
-.A General topology
-[#img-general]
-[caption="Figure 1: "]
-image::dbz-to-jdbc.svg[Scenario topology]
+[.centered-image.responsive-image]
+====
+++++
+<img src="/assets/images/dbz-to-jdbc.svg" style="max-width:100%;" class="responsive-image">
+++++
+Figure 1: A General topology
+====
 
 &nbsp; +
 
@@ -30,10 +33,13 @@ I.e. this instance will serve as an event producer and an event consumer:
 
 &nbsp; +
 
-.A Simplified topology
-[#img-general]
-[caption="Figure 2: "]
-image::dbz-to-jdbc-simplified.svg[Scenario topology]
+[.centered-image.responsive-image]
+====
+++++
+<img src="/assets/images/dbz-to-jdbc-simplified.svg" style="max-width:100%;" class="responsive-image">
+++++
+Figure 2: A Simplified topology
+====
 
 == Configuration
 We will use this https://github.com/debezium/debezium-examples/tree/master/unwrap-smt[compose] for a fast deployment of the demo.

--- a/_posts/2018-01-17-streaming-to-elasticsearch.adoc
+++ b/_posts/2018-01-17-streaming-to-elasticsearch.adoc
@@ -22,10 +22,12 @@ And, at the same time, the Confluent https://github.com/confluentinc/kafka-conne
 
 &nbsp; +
 
-.A general topology
-[#img-general]
-[caption="Figure 1: "]
-image::dbz-to-multiple.svg[Scenario topology]
+====
+++++
+<img src="/assets/images/dbz-to-multiple.svg" style="max-width:100%;" class="responsive-image">
+++++
+Figure 1: A general topology
+====
 
 &nbsp; +
 
@@ -35,10 +37,12 @@ In this example, we'll deploy all three connectors to a single Kafka Connect ins
 
 &nbsp; +
 
-.A simplified topology
-[#img-general]
-[caption="Figure 2: "]
-image::dbz-to-multiple-simplified.svg[Scenario topology]
+====
+++++
+<img src="/assets/images/dbz-to-multiple-simplified.svg" style="max-width:100%;" class="responsive-image">
+++++
+Figure 2: A simplified topology
+====
 
 == Configuration
 

--- a/_posts/2018-03-08-creating-ddd-aggregates-with-debezium-and-kafka-streams.adoc
+++ b/_posts/2018-03-08-creating-ddd-aggregates-with-debezium-and-kafka-streams.adoc
@@ -20,8 +20,12 @@ and https://kafka.apache.org/[Apache Kafka] with relative ease and effectively n
 
 As an example, consider the following microservice-based architecture of an order management system:
 
-[.centered-image]
-image::msa_streaming.png[Microservice-based architecture of an order management system]
+[.centered-image.responsive-image]
+====
+++++
+<img src="/assets/images/msa_streaming.png" style="max-width:100%;" class="responsive-image">
+++++
+====
 
 This system comprises three services, _Order_, _Item_ and _Stock_.
 If the _Order_ service receives an order request, it will need information from the other two,

--- a/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
+++ b/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
@@ -19,11 +19,13 @@ The result of this exercise should be similar to the recent link:/blog/2018/03/0
 
 First let's look at the entities in the database and the relations between them.
 
-.Entity diagram of the example entities
-[#img-general]
-[caption="Figure 1: "]
-[.centered-image]
-image::tutorial-erd.svg[Entity diagram]
+[.centered-image.responsive-image]
+====
+++++
+<img src="/assets/images/tutorial-erd.svg" style="max-width:100%;" class="responsive-image">
+++++
+Figure 1: Entity diagram of the example entities
+====
 
 &nbsp; +
 

--- a/_posts/2018-08-30-debezium-0-8-2-released.adoc
+++ b/_posts/2018-08-30-debezium-0-8-2-released.adoc
@@ -18,7 +18,7 @@ The 0.8.2 release contains link:/docs/releases/#release-0-8-2[10 fixes] overall,
 For instance, implicit non-nullable primary key columns will be handled correctly now using the new Antlr-based DDL parser (https://issues.redhat.com/browse/DBZ-860[DBZ-860]).
 Also the link:/docs/connectors/mongodb/[MongoDB connector] saw a bug fix (https://issues.redhat.com/browse/DBZ-838[DBZ-838]): initial snapshots will be interrupted now if the connector is requested to stop
 (e.g. when shutting down Kafka Connect).
-More a useful improvement rather than a bug fix is the link:/docs/connectors/postgres/[Postgres connector's] capability to add the table, schema and database names to the `source` block of emitted CDC events (https://issues.redhat.com/browse/DBZ-866[DBZ-866]).
+More a useful improvement rather than a bug fix is the link:/docs/connectors/postgresql/[Postgres connector's] capability to add the table, schema and database names to the `source` block of emitted CDC events (https://issues.redhat.com/browse/DBZ-866[DBZ-866]).
 
 Thanks a lot to community members https://github.com/jchipmunk[Andrey Pustovetov], https://github.com/CliffWheadon[Cliff Wheadon] and https://github.com/oripwk[Ori Popowski] for their contributions to this release!
 

--- a/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
+++ b/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
@@ -12,7 +12,7 @@ This is a bugfix release to the current stable release line of Debezium, 0.8.x, 
 There are link:/docs/releases/#release-0-8-3-final[14 fixes] in this release.
 As in earlier 0.8.x releases, we've further improved the new Antlr-based DDL parser used by the link:/docs/connectors/mysql/[MySQL connector] (see https://issues.redhat.com/browse/DBZ-901[DBZ-901], https://issues.redhat.com/browse/DBZ-903[DBZ-903] and https://issues.redhat.com/browse/DBZ-910[DBZ-910]).
 
-The link:/docs/connectors/postgres/[Postgres connector] saw a huge improvement to its start-up time for databases with lots of custom types (https://issues.redhat.com/browse/DBZ-899[DBZ-899]).
+The link:/docs/connectors/postgresql/[Postgres connector] saw a huge improvement to its start-up time for databases with lots of custom types (https://issues.redhat.com/browse/DBZ-899[DBZ-899]).
 The user reporting this issue had nearly 200K entries in pg_catalog.pg_type, and due to an N + 1 SELECT issue within the Postgres driver itself, this caused the connector to take 24 minutes to start.
 By using a custom query for obtaining the type metadata, we were able to cut down this time to 5 seconds!
 Right now we're working with the maintainers of the Postgres driver to get this issue fixed upstream, too.

--- a/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
+++ b/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
@@ -83,7 +83,7 @@ Amongst them are
 Community member Ian Axelrod provided a fix for a potential performance issue,
 where changes to tables with TOAST columns in Postgres would cause repeated updates to the connector's internal schema metadata,
 which can be a costly operation (https://issues.redhat.com/browse/DBZ-911[DBZ-911]).
-Please refer to the link:/docs/connectors/postgres/[Postgres connector documentation] for details on the new `schema.refresh.mode` option,
+Please refer to the link:/docs/connectors/postgresql/[Postgres connector documentation] for details on the new `schema.refresh.mode` option,
 which deals with this issue.
 
 In terms of version upgrades we migrated to the latest releases of the MySQL (https://issues.redhat.com/browse/DBZ-763[DBZ-763], https://issues.redhat.com/browse/DBZ-764[DBZ-764]) and Postgres drivers (https://issues.redhat.com/browse/DBZ-912[DBZ-912]).

--- a/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
+++ b/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
@@ -11,7 +11,7 @@ The Debezium team is happy to announce the release of Debezium *0.9.2.Final*!
 This is mostly a bug-fix release and a drop-in replacement for earlier Debezium 0.9.x versions.
 Overall, https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%200.9.2.Final[18 issues] were resolved.
 
-A couple of fixes relate to the link:/docs/connectors/postgres/[Debezium Postgres connector]:
+A couple of fixes relate to the link:/docs/connectors/postgresql/[Debezium Postgres connector]:
 
 * When not using `REPLICA IDENTITY FULL`, certain data types could trigger exceptions for update or delete events; those are fixed now
 (https://issues.redhat.com/browse/DBZ-1141[DBZ-1141], https://issues.redhat.com/browse/DBZ-1149[DBZ-1149])

--- a/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
+++ b/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
@@ -30,7 +30,7 @@ Its usage will be described in the documentation soon; for the time being please
 
 == Bug fixes
 
-We did a couple of fixes related to the link:/docs/connectors/postgres/[Debezium Postgres connector]:
+We did a couple of fixes related to the link:/docs/connectors/postgresql/[Debezium Postgres connector]:
 
 * A regression that introduced a deadlock in snapshotting process has been fixed (https://issues.redhat.com/browse/DBZ-1161[DBZ-1161])
 * The `hstore` datatype works correctly in snapshot phase (https://issues.redhat.com/browse/DBZ-1162[DBZ-1162])

--- a/license.asciidoc
+++ b/license.asciidoc
@@ -1,0 +1,15 @@
+---
+layout: page-menu
+title: Debezium License
+permalink: /license
+---
+= Debezium License
+:awestruct-layout: doc
+:linkattrs:
+:icons: font
+
+== License and Copyright
+
+All code of the Debezium project is licensed under the http://www.apache.org/licenses/LICENSE-2.0[Apache License 2.0]. The website is licensed under http://creativecommons.org/licenses/by-sa/4.0/[Creative Commons Attribution-ShareAlike 4.0].
+
+The *Debezium* software is copyright 2020 by Red Hat, Inc. The *Debezium* name, logo and other marks are trademarks of Red Hat, Inc. and may not be used without prior written permission.

--- a/redirects/docs.asciidoc
+++ b/redirects/docs.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs
+layout: redirect
+redir_to: /documentation
+---

--- a/redirects/docs_amq-streams.asciidoc
+++ b/redirects/docs_amq-streams.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/amq-streams
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/operations/amq-streams.html
+---

--- a/redirects/docs_architecture.asciidoc
+++ b/redirects/docs_architecture.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/architecture
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/architecture.html
+---

--- a/redirects/docs_code-of-conduct.asciidoc
+++ b/redirects/docs_code-of-conduct.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/code-of-conduct
+layout: redirect
+redir_to: /community/code-of-conduct
+---

--- a/redirects/docs_configuration_avro.asciidoc
+++ b/redirects/docs_configuration_avro.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/avro
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/configuration/avro.html
+---

--- a/redirects/docs_configuration_event-flattening.asciidoc
+++ b/redirects/docs_configuration_event-flattening.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/event-flattening
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/configuration/event-flattening.html
+---

--- a/redirects/docs_configuration_logging.asciidoc
+++ b/redirects/docs_configuration_logging.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/logging
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/operations/logging.html
+---

--- a/redirects/docs_configuration_mongo-event-flattening.asciidoc
+++ b/redirects/docs_configuration_mongo-event-flattening.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/mongodb-event-flattening
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/configuration/mongodb-event-flattening.html
+---

--- a/redirects/docs_configuration_outbox-event-router.asciidoc
+++ b/redirects/docs_configuration_outbox-event-router.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/outbox-event-router
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/configuration/outbox-event-router.html
+---

--- a/redirects/docs_configuration_topic-routing.asciidoc
+++ b/redirects/docs_configuration_topic-routing.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/configuration/topic-routing
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/configuration/topic-routing.html
+---

--- a/redirects/docs_connectors.asciidoc
+++ b/redirects/docs_connectors.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/index.html
+---

--- a/redirects/docs_connectors_cassandra.asciidoc
+++ b/redirects/docs_connectors_cassandra.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/cassandra
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/cassandra.html
+---

--- a/redirects/docs_connectors_mongodb.asciidoc
+++ b/redirects/docs_connectors_mongodb.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/mongodb
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/mongodb.html
+---

--- a/redirects/docs_connectors_mysql.asciidoc
+++ b/redirects/docs_connectors_mysql.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/mysql
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/mysql.html
+---

--- a/redirects/docs_connectors_oracle.asciidoc
+++ b/redirects/docs_connectors_oracle.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/oracle
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/oracle.html
+---

--- a/redirects/docs_connectors_postgresql.asciidoc
+++ b/redirects/docs_connectors_postgresql.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/postgresql
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/postgresql.html
+---

--- a/redirects/docs_connectors_sqlserver.asciidoc
+++ b/redirects/docs_connectors_sqlserver.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/connectors/sqlserver
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/sqlserver.html
+---

--- a/redirects/docs_contribute.asciidoc
+++ b/redirects/docs_contribute.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/contribute
+layout: redirect
+redir_to: /community/contribute
+---

--- a/redirects/docs_documentation_install-stable.asciidoc
+++ b/redirects/docs_documentation_install-stable.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/install/stable
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/install.html
+---

--- a/redirects/docs_embedded.asciidoc
+++ b/redirects/docs_embedded.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/embedded
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/operations/embedded.html
+---

--- a/redirects/docs_faq.asciidoc
+++ b/redirects/docs_faq.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/faq
+layout: redirect
+redir_to: /documentation/faq
+---

--- a/redirects/docs_features.asciidoc
+++ b/redirects/docs_features.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/features
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/features.html
+---

--- a/redirects/docs_install_development.asciidoc
+++ b/redirects/docs_install_development.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/install/development
+layout: redirect
+redir_to: /documentation/reference/!LATEST_VERSION!/install.html
+---

--- a/redirects/docs_install_postgres-plugins.asciidoc
+++ b/redirects/docs_install_postgres-plugins.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/install/postgres-plugins
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/postgres_plugins.html
+---

--- a/redirects/docs_install_stable.asciidoc
+++ b/redirects/docs_install_stable.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/install/stable
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/install.html
+---

--- a/redirects/docs_monitoring.asciidoc
+++ b/redirects/docs_monitoring.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/monitoring
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/operations/monitoring.html
+---

--- a/redirects/docs_mysql.asciidoc
+++ b/redirects/docs_mysql.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/mysql
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/connectors/mysql.html
+---

--- a/redirects/docs_online-resources.asciidoc
+++ b/redirects/docs_online-resources.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/online-resources
+layout: redirect
+redir_to: /documentation/online-resources
+---

--- a/redirects/docs_openshift.asciidoc
+++ b/redirects/docs_openshift.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/openshift
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/operations/openshift.html
+---

--- a/redirects/docs_releases.asciidoc
+++ b/redirects/docs_releases.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/releases
+layout: redirect
+redir_to: /releases/!LATEST_VERSION!/release-notes
+---

--- a/redirects/docs_roadmap.asciidoc
+++ b/redirects/docs_roadmap.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/roadmap
+layout: redirect
+redir_to: /roadmap
+---

--- a/redirects/docs_tutorial.asciidoc
+++ b/redirects/docs_tutorial.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /docs/tutorial
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/tutorial.html
+---

--- a/redirects/documentation_architecture.asciidoc
+++ b/redirects/documentation_architecture.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/architecture
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/architecture.html
+---

--- a/redirects/documentation_features.asciidoc
+++ b/redirects/documentation_features.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/features
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/tutorial.html
+---

--- a/redirects/documentation_install_stable.asciidoc
+++ b/redirects/documentation_install_stable.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/install/stable
+layout: redirect
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/install.html
+---


### PR DESCRIPTION
Handle redirects for links in old blog posts, etc.  
- created redirects folder which contains files for all of the necessary redirects.  They just contain front matter with the permlink and a 'redir-to' variable
- Created a redirect layout which does a substitution for the "redir_to" front matter variable to put the correct version
- Fixed issues with some of the blog posts (images and redirects)
- added missing license.asciidoc