### PR TITLE
migration - updates to blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,10 @@ defaults:
     scope:
       type: "posts"
     values:
-      permalink: /blog/:title/
+      permalink: /blog/:year/:month/:day/:title/
+
+# Excerpt separator
+excerpt_separator: "+++<!-- more -->+++"
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
@@ -66,7 +69,7 @@ collections:
     permalink: /:name  
   posts: 
     output: true
-    permalink: /blog/:title/
+    permalink: /blog/:year/:month:/:day/:title/
 
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem

--- a/_includes/blog-feed.html
+++ b/_includes/blog-feed.html
@@ -41,8 +41,8 @@
             </div> 
           </div>
         <div class="grid__item width-12-12">
-          {% if post.synopsis %}
-            <p>{{ post.synopsis | strip_html }}</p>
+          {% if post.content contains "<!-- more -->" %}
+            <p>{{ post.excerpt }}</p>
           {% else %}
             <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
           {% endif %}

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -39,8 +39,8 @@ layout: base
                 </div> 
               </div>
             <div class="grid__item width-12-12">
-              {% if post.synopsis %}
-                <p>{{ post.synopsis | strip_html }}</p>
+              {% if post.content contains "<!-- more -->" %}
+                <p>{{ post.excerpt }}</p>
               {% else %}
                 <p>{{ post.content | strip_html | truncatewords: 75 }}</p>
               {% endif %}

--- a/_posts/2016-03-18-Debezium-0-1-Released.adoc
+++ b/_posts/2016-03-18-Debezium-0-1-Released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title: Debezium 0.1 Released
+date:   2016-03-18 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.1 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 Debezium is a distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
 
@@ -12,6 +12,8 @@ Now the good news -- *_Debezium 0.1 is now available_* and includes several sign
 
 * A link:/docs/connectors/mysql/[connector for MySQL] to monitor MySQL databases. It's a Kafka Connect source connector, so simply install it into a Kafka Connect service (see below) and use the service's REST API to configure and manage connectors to each DBMS server. The connector reads the MySQL binlog and generates data change events for every committed row-level modification in the monitored databases. The MySQL connector generates events based upon the tables' structure at the time the row is changed, and it automatically handles changes to the table structures.
 * A small library so applications can link:/docs/embedded/[embed any Kafka Connect connector] and consume data change events read directly from the source system. This provides a much lighter weight system (since Zookeeper, Kafka, and Kafka Connect services are not needed), but as a consequence is not as fault tolerant or reliable since the application must maintain state normally kept inside Kafka's distributed and replicated logs. Thus the application becomes completely responsible for managing all state.
+
++++<!-- more -->+++
 
 Although Debezium is really intended to be used as turnkey services, all of Debezium's JARs and other artifacts are available in http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.debezium%22[Maven Central]. Detailed information about the features, tasks, and bugs are outlined in our release notes.
 

--- a/_posts/2016-04-14-Debezium-website.adoc
+++ b/_posts/2016-04-14-Debezium-website.adoc
@@ -1,9 +1,9 @@
 ---
+layout: post
+title: Debezium Website
+date:   2016-04-14 10:19:59 -0600
 tags: [ website ]
+author: rhauch
 ---
-= Debezium Website
-rhauch
-:awestruct-tags: [ website ]
-:awestruct-layout: blog-post
 
 As you may have noticed, we have a https://debezium.io[new website] with link:/docs/[documentation], a link:/blog/[blog], and information about the link:/community/[Debezium community] and how you can link:/docs/contribute/[contribute]. Let us know what you think, and link:/docs/contribute/[contribute improvements].

--- a/_posts/2016-04-15-parsing-ddl.adoc
+++ b/_posts/2016-04-15-parsing-ddl.adoc
@@ -1,16 +1,18 @@
 ---
-tags:  [ mysql, sql ]
+layout: post
+title: Parsing DDL
+date:   2016-04-15 10:19:59 -0600
+tags: [ mysql, sql ]
+author: rhauch
 ---
-= Parsing DDL
-rhauch
-:awestruct-tags: [ mysql, sql ]
-:awestruct-layout: blog-post
 
 When our link:/docs/connectors/mysql/[MySQL connector] is reading the binlog of a MySQL server or cluster, it parses the DDL statements in the log and builds an in-memory model of each table's schema as it evolves over time. This process is important because the connector generates events for each table using the definition of the table at the time of each event. We can't use the database's _current_ schema, since it may have changed since the point in time (or position in the log) where the connector is reading.
 
 Parsing DDL of MySQL or any other major relational database can seem to be a daunting task. Usually each DBMS has a highly-customized SQL grammar, and although the _data manipulation language_ (DML) statements are often fairly close the standards, the _data definition language_ (DDL) statements are usually less so and involve more DBMS-specific features.
 
 So given this, why did we write our own DDL parser for MySQL? Let's first look at what Debezium needs a DDL parser to do.
+
++++<!-- more -->+++
 
 == Parsing DDL in the Debezium MySQL connector
 

--- a/_posts/2016-05-31-Debezium-on-Kubernetes.adoc
+++ b/_posts/2016-05-31-Debezium-on-Kubernetes.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title: Debezium on Kubernetes
+date:   2016-05-31 10:19:59 -0600
 tags: [ mysql, sql, kubernetes, docker, kafka ]
+author: ceposta
 ---
-= Debezium on Kubernetes
-ceposta
-:awestruct-tags: [ mysql, sql, kubernetes, docker, kafka ]
-:awestruct-layout: blog-post
 
 _Update (Oct. 11 2019): An alternative, and much simpler, approach for running Debezium (and Apache Kafka and Kafka Connect in general) on Kubernetes is to use a K8s operator such as https://strimzi.ioi/[Strimzi].
 You can find instructions for the set-up of Debezium on OpenShift link:/documentation/reference/0.10/operations/openshift.html[here], and similar steps apply for plain Kubernetes._
@@ -14,6 +14,8 @@ Our link:/docs/tutorial/[Debezium Tutorial] walks you step by step through using
 link:http://kubernetes.io[Kubernetes] is a container (Docker/Rocket/Hyper.sh) cluster management tool. Like many other popular cluster management and compute resource scheduling platforms, Kubernetes' roots are in Google, who is no stranger to running containers at scale. They start, stop, and cluster link:https://cloudplatform.googleblog.com/2015/01/in-coming-weeks-we-will-be-publishing.html[2 billion containers per week] and they contributed a lot of the Linux kernel underpinnings that make containers possible. link:http://research.google.com/pubs/pub43438.html[One of their famous papers] talks about an internal cluster manager named Borg. With Kubernetes, Google got tired of everyone implementing their papers in Java so they decided to implement this one themselves :)
 
 Kubernetes is written in Go-lang and is quickly becoming the de-facto API for scheduling, managing, and clustering containers at scale. This blog isn't intended to be a primer on Kubernetes, so we recommend heading over to the link:http://kubernetes.io/docs/getting-started-guides/[Getting Started] docs to learn more about Kubernetes.
+
++++<!-- more -->+++
 
 == Getting started
 

--- a/_posts/2016-06-10-Debezium-0.2.1-Released.adoc
+++ b/_posts/2016-06-10-Debezium-0.2.1-Released.adoc
@@ -1,12 +1,14 @@
 ---
+layout: post
+title: Debezium 0.2.1 Released
+date:   2016-06-10 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.2.1 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 I'm happy to announce that **Debezium 0.2.1 is now available**. The link:/docs/connectors/mysql/[MySQL connector] has been significantly improved and is now able to monitor and produce change events for link:/docs/connectors/mysql/#ha-mysql-clusters#enabling-gtids[HA MySQL clusters] using link:/docs/connectors/mysql/[GTIDs], perform a link:/docs/connectors/mysql/#snapshots[consistent snapshot] when starting up the first time, and has a completely redesigned link:/docs/connectors/mysql/#events[event message structure] that provides a ton more information with every event. Our link:/docs/releases/[change log] has all the details about bugs, enhancements, new features, and backward compatibility notices. We've also updated our link:/docs/tutorial/[tutorial].
+
++++<!-- more -->+++
 
 [NOTE]
 ====

--- a/_posts/2016-06-22-Debezium-0-2-2-Released.adoc
+++ b/_posts/2016-06-22-Debezium-0-2-2-Released.adoc
@@ -5,16 +5,14 @@ layout: post
 author: gmorling
 tags: [ releases, mysql, docker ]
 ---
-= Debezium 0.2.2 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 I'm happy to announce that **Debezium 0.2.2 is now available**. This release fixes several bugs in the MySQL connector that can produce change events with incorrect `source` metadata, and that eliminates the possibility a poorly-timed connector crash causing the connector to only process some of the rows in a multi-row MySQL event. See our link:/docs/releases/#release-0-2-2[release notes] for details of these changes and for upgrading recommendations.
 
 Also, thanks to a community member for https://issues.redhat.com/projects/DBZ/issues/DBZ-80[reporting] that Debezium 0.2.x can only be used with Kafka Connect 0.9.0.1. Debezium 0.2.x cannot be used with Kafka Connect 0.10.0.0 because of its https://issues.apache.org/jira/browse/KAFKA-3006[backward incompatible changes to the consumer API]. Our next release of Debezium will support Kafka 0.10.x.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] (with label `0.2` and `latest`) used in our link:/docs/tutorial/[tutorial].
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-07-26-Debezium-0-2-3-Released.adoc
+++ b/_posts/2016-07-26-Debezium-0-2-3-Released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title: Debezium 0.2.3 Released
+date:   2016-07-26 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.2.3 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 I'm happy to announce that **Debezium 0.2.3 is now available** for use with Kafka Connect 0.9.0.1. This release corrects the MySQL connector behavior when working with `TINYINT` and `SMALLINT` columns or with `TIME`, `DATE`, and `TIMESTAMP` columns. See our link:/docs/releases/#release-0-2-3[release notes] for details of these changes and for upgrading recommendations.
 
@@ -12,6 +12,8 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 
 Thanks to Chris, Christian, Laogang, and Tony for their help with the release, issues, discussions, contributions, and questions!
 Stay tuned for our next release, which will be 0.3 and will have a new MongoDB connector and will support Kafka Connect 0.10.0.0.
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-08-02-capturing-changes-from-mysql.adoc
+++ b/_posts/2016-08-02-capturing-changes-from-mysql.adoc
@@ -1,12 +1,14 @@
 ---
+layout: post
+title: Capturing changes from MySQL
+date:   2016-08-02 10:19:59 -0600
 tags: [ mysql ]
+author: rhauch
 ---
-= Capturing changes from MySQL
-rhauch
-:awestruct-tags: [ mysql ]
-:awestruct-layout: blog-post
 
 Change data capture is a hot topic. Debezium's goal is to make change data capture easy for multiple DBMSes, but admittedly we're still a young open source project and so far we've only released a link:/docs/connectors/mysql/[connector for MySQL] with a link:/docs/connectors/mongodb/[connector for MongoDB] that's just around the corner. So it's great to see how others are using and implementing change data capture. In this post, we'll review Yelp's approach and see how it is strikingly similar to Debezium's MySQL connector.
+
++++<!-- more -->+++
 
 == Streaming data at Yelp
 
@@ -22,7 +24,7 @@ Yelp's Real-Time Data Pipeline records changes to data on totally ordered distri
 
 == How Yelp captures MySQL changes
 
-Perhaps most interesting for Debezium is how Yelp captures the committed changes in their MySQL databases and write them to Kafka topics. Their http://engineeringblog.yelp.com/2016/08/streaming-mysql-tables-in-real-time-to-kafka.html[second post in the series] goes into a lot more detail about their MySQLStreamer process that reads the MySQL binary log and continously processes the DDL statements and DML operations that appear in the log, generating the corresponding _insert_, _update_, _delete_, and _refresh_ events, and writing these event messages to a separate Kafka topic for each MySQL table. We've link:/blog/2016-04-15-parsing-ddl/[mentioned before] that MySQL's row-level binlog events that result from the DML operation don't include the full definition of the columns, so knowing what the columns mean in each event requires process the DDL statements that also appear in the binlog. Yelp uses a separate MySQL instance it calls the _schema tracker database_, which behaves like a MySQL slave to which are applied only the DDL statements they read from the binlog. This technique lets Yelp's MySQLStreamer system know the state of the database schema and the structure of its tables at the point in the binlog where they are processing events. This is pretty interesting, because it uses the MySQL engine to handle the DDL parsing.
+Perhaps most interesting for Debezium is how Yelp captures the committed changes in their MySQL databases and write them to Kafka topics. Their http://engineeringblog.yelp.com/2016/08/streaming-mysql-tables-in-real-time-to-kafka.html[second post in the series] goes into a lot more detail about their MySQLStreamer process that reads the MySQL binary log and continously processes the DDL statements and DML operations that appear in the log, generating the corresponding _insert_, _update_, _delete_, and _refresh_ events, and writing these event messages to a separate Kafka topic for each MySQL table. We've link:/blog/2016/04/15/parsing-ddl/[mentioned before] that MySQL's row-level binlog events that result from the DML operation don't include the full definition of the columns, so knowing what the columns mean in each event requires process the DDL statements that also appear in the binlog. Yelp uses a separate MySQL instance it calls the _schema tracker database_, which behaves like a MySQL slave to which are applied only the DDL statements they read from the binlog. This technique lets Yelp's MySQLStreamer system know the state of the database schema and the structure of its tables at the point in the binlog where they are processing events. This is pretty interesting, because it uses the MySQL engine to handle the DDL parsing.
 
 Yelp's MySQLStreamer process uses another MySQL database to track internal state describing its position in the binlog, what events have been successfully published to Kafka, and, because the binlog position varies on each replica, replica-independent information about each transaction. This latter information is similar to MySQL GTIDs, although Yelp is using earlier versions of MySQL that do not support GTIDs.
 
@@ -32,7 +34,7 @@ Yelp's MySQLStreamer mechanism is quite ingenious in its use of MySQL and multip
 
 == Similar purpose, similar approach
 
-Debezium is an open source project that is building a change data capture for a variety of DBMSes. Like Yelp's MySQLStreamer, Debezium's link:/docs/connectors/mysql/[MySQL Connector] can continously capture the committed changes to MySQL database rows and record these events in a separate Kafka topic for each table. When first started, Debezium's MySQL Connector can perform an initial consistent snapshot and then begin reading the MySQL binlog. It uses both DDL and DML operations that appear in the binlog, directly link:/blog/2016-04-15-parsing-ddl/[parsing and using the DDL statements] to learn the changes to each table's structure and the mapping of each insert, update, and delete binlog event. And each resulting change event written to Kafka includes information about the originating MySQL server and its binlog position, as well as the before and/or after states of the affected row.
+Debezium is an open source project that is building a change data capture for a variety of DBMSes. Like Yelp's MySQLStreamer, Debezium's link:/docs/connectors/mysql/[MySQL Connector] can continously capture the committed changes to MySQL database rows and record these events in a separate Kafka topic for each table. When first started, Debezium's MySQL Connector can perform an initial consistent snapshot and then begin reading the MySQL binlog. It uses both DDL and DML operations that appear in the binlog, directly link:/blog/2016/04/15/parsing-ddl/[parsing and using the DDL statements] to learn the changes to each table's structure and the mapping of each insert, update, and delete binlog event. And each resulting change event written to Kafka includes information about the originating MySQL server and its binlog position, as well as the before and/or after states of the affected row.
 
 However, unlike Yelp's MySQLStreamer, the Debezium MySQL connector doesn't need or use extra MySQL databases to parse DDL or to store the connector's state. Instead, Debezium is built on top of Kafka Connect, which is a new Kafka library that provides much of the generic functionality of reliably pulling data from external systems, pushing it into Kafka topics, and tracking what data has already been processed. Kafka Connect stores this state inside Kafka itself, simplifying the operational footprint. Debezium's MySQL connector can then focus on the details of performing a consistent snapshot when required, reading the binlog, and converting the binlog events into useful change events.
 

--- a/_posts/2016-08-16-Debezium-0-2-4-Released.adoc
+++ b/_posts/2016-08-16-Debezium-0-2-4-Released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title: Debezium 0.2.4 Released
+date:   2016-08-16 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.2.4 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 I'm happy to announce that **Debezium 0.2.4 is now available** for use with Kafka Connect 0.9.0.1. This release adds more verbose logging during MySQL snapshots, enables taking snapshots of very large MySQL databases, and correct a potential exception during graceful shutdown. See our link:/docs/releases/#release-0-2-4[release notes] for details of these changes and for upgrading recommendations.
 
@@ -12,6 +12,8 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 
 Thanks to David and wangshao for their help with the release, issues, discussions, contributions, and questions!
 Stay tuned for our next release, which will be 0.3 and will have a new MongoDB connector and will support Kafka Connect 0.10.0.1.
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-08-16-Debezium-0-3-0-Released.adoc
+++ b/_posts/2016-08-16-Debezium-0-3-0-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title: Debezium 0.3.0 Released
+date:   2016-08-16 10:19:59 -0600
 tags: [ releases, mysql, mongodb, docker ]
+author: rhauch
 ---
-= Debezium 0.3.0 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, docker ]
-:awestruct-layout: blog-post
 
 After a few weeks delay, **Debezium 0.3.0 is now available** for use with Kafka Connect 0.10.0.1. This release contains an updated link:/docs/connectors/mysql/[MySQL connector] with quite a few bug fixes, and a new *_link:/docs/connectors/mongodb/[MongoDB connector]_* that captures the changes made to a MongoDB replica set or MongoDB sharded cluster. See the link:/docs/connectors/[documentation] for details about how to configure these connectors and how they work.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] (with labels `0.3` and `latest`) used in our link:/docs/tutorial/[tutorial].
 
 Thanks to Andrew, Bhupinder, Chris, David, Horia, Konstantin, Tony, and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-08-30-Debezium-0-3-1-Released.adoc
+++ b/_posts/2016-08-30-Debezium-0-3-1-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title: Debezium 0.3.1 Released
+date:   2016-08-30 10:19:59 -0600
 tags: [ releases, mysql, mongodb, docker ]
+author: rhauch
 ---
-= Debezium 0.3.1 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.1** is now available for use with Kafka Connect 0.10.0.1. This release contains an updated link:/docs/connectors/mysql/[MySQL connector] with a handful of bug fixes and two significant but backward-compatible changes. First, the MySQL connector now supports using secure connections to MySQL, adding to the existing ability to connect securely to Kafka. Second, the MySQL connector is able to capture MySQL string values using the proper character sets so that any values stored in the database can be captured correctly in events. See our link:/docs/releases/#release-0-3-1[release notes] for details of these changes and for upgrading recommendations.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Chris, Akshath, barten, and and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-09-19-Serializing-Debezium-events-with-Avro.adoc
+++ b/_posts/2016-09-19-Serializing-Debezium-events-with-Avro.adoc
@@ -1,14 +1,16 @@
 ---
+layout: post
+title: Serializing Debezium events with Avro 
+date:  2016-09-19 10:19:59 -0600
 tags: [ kafka, avro, serialization ]
+author: rhauch
 ---
-= Serializing Debezium events with Avro
-rhauch
-:awestruct-tags: [ kafka, avro, serialization ]
-:awestruct-layout: blog-post
 
 Although Debezium makes it easy to capture database changes and record them in Kafka, one of the more important decisions you have to make is _how_ those change events will be serialized in Kafka. Every message in Kafka has a key and a value, and to Kafka these are opaque byte arrays. But when you set up Kafka Connect, you have to say how the Debezium event keys and values should be serialized to a binary form, and your consumers will also have to deserialize them back into a usable form.
 
 Debezium event keys and values are both structured, so JSON is certainly a reasonable option -- it's flexible, ubiquitous, and language agnostic, but on the other hand it's quite verbose. One alternative is Avro, which is also flexible and language agnostic, but also faster and results in smaller binary representations. Using Avro requires a bit more setup effort on your part and some additional software, but the advantages are often worth it.
+
++++<!-- more -->+++
 
 == Kafka serializers and deserializers
 

--- a/_posts/2016-09-26-Debezium-0-3-2-Released.adoc
+++ b/_posts/2016-09-26-Debezium-0-3-2-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title: Debezium 0.3.2 Released
+date:  2016-09-26 10:19:59 -0600
 tags: [ releases, mysql, mongodb, docker ]
+author: rhauch
 ---
-= Debezium 0.3.2 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.2** is now available for use with Kafka Connect 0.10.0.1. This release contains a handful of bug fixes and minor improvements for the link:/docs/connectors/mysql/[MySQL connector] and link:/docs/connectors/mongodb/[MongoDB connector]. The MySQL connector better handles `BIT(n)` values and http://dev.mysql.com/doc/refman/5.7/en/date-and-time-types.html[zero-value] date and timestamp values. This release also improves the log messages output by the MySQL and MongoDB connectors to better represent the ongoing activity when consuming the changes from the source database. See the link:/docs/releases/[release notes] for specifics.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial]. We've also updated the tutorial to use the https://docs.docker.com/engine/installation/[latest Docker installations] on Linux, Windows, and OS X.
 
 Thanks to Akshath, Colum, Emmanuel, Konstantin, Randy, RenZhu, Umang, and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-10-18-Debezium-0-3-3-Released.adoc
+++ b/_posts/2016-10-18-Debezium-0-3-3-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title: Debezium 0.3.3 Released
+date:  2016-10-18 10:19:59 -0600
 tags: [ releases, mysql, mongodb, docker ]
+author: rhauch
 ---
-= Debezium 0.3.3 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.3** is now available for use with Kafka Connect 0.10.0.1. This release contains a handful of bug fixes and minor improvements for the link:/docs/connectors/mysql/[MySQL connector], including better handling of `BIT(n)` values, `ENUM` and `SET` values, and GTID sets, This release also improves the log messages output by the MySQL connectors to better represent the ongoing activity when consuming the changes from the source database. See the link:/docs/releases/[release notes] for specifics.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial]. We've also updated the tutorial to use the https://docs.docker.com/engine/installation/[latest Docker installations] on Linux, Windows, and OS X.
 
 Thanks to Akshath, Chris, Randy, Prannoy, Umang, Horia, and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-10-19-Support-for-MySQL-JSON-typpe-coming-soon.adoc
+++ b/_posts/2016-10-19-Support-for-MySQL-JSON-typpe-coming-soon.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title: Support for MySQL's JSON type coming soon
+date:   2016-10-19 10:19:59 -0600
 tags: [ mysql, json ]
+author: rhauch
 ---
-= Support for MySQL's JSON type coming soon
-rhauch
-:awestruct-tags: [ mysql, json ]
-:awestruct-layout: blog-post
 
 MySQL 5.7 introduced a new data type for http://mysqlserverteam.com/whats-new-in-mysql-5-7-generally-available/[storing and working with JSON data]. Clients can define tables with columns using the new https://dev.mysql.com/doc/refman/5.7/en/json.html[`JSON` datatype], and they can store and read JSON data using SQL statements and new built-in JSON functions to construct JSON data from other relational columns, introspect the structure of JSON values, and search within and manipulate JSON data. It possible to define generated columns on tables whose values are computed from the JSON value in another column of the same table, and to then define indexes with those generated columns. Overall, this is really a very powerful feature in MySQL.
 
 Debezium's MySQL connector will support the `JSON` datatype starting with the upcoming 0.3.4 release. JSON document, array, and scalar values will appear in change events as strings with `io.debezium.data.json` for the schema name. This will make it natural for consumers to work with JSON data. BTW, this is the same semantic schema type used by the MongoDB connector to represent JSON data.
 
 This sounds straightforward, and we hope it is. But https://issues.redhat.com/browse/DBZ-126[implementing this] required a fair amount of work. That's because although MySQL exposes JSON data as strings to client applications, _internally_ it stores all JSON data in a special binary form that allows the MySQL engine to efficiently access the JSON data in queries, JSON functions and generated columns. All JSON data appears in the binlog in this binary form as well, which meant that we had to parse the binary form ourselves if we wanted to extract the more useful string representation. Writing and testing this parser took a bit of time and effort, and ultimately we https://github.com/shyiko/mysql-binlog-connector-java/issues/115[donated it] to the excellent https://github.com/shyiko/mysql-binlog-connector-java[MySQL binlog client library] that the connector uses internally to read the binlog events.
+
++++<!-- more -->+++
 
 We'd like to thank https://github.com/shyiko[Stanley Shyiko] for guiding us and helping us debug the final problems with parsing JSON in the binlog, for accepting our proposed changes into his library, for releasing his library quickly when needed, and for being so responsive on this and other issues!

--- a/_posts/2016-10-25-Debezium-0-3-4-Released.adoc
+++ b/_posts/2016-10-25-Debezium-0-3-4-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title: Debezium 0.3.4 Released
+date:   2016-10-25 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.3.4 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.4** is now available for use with Kafka Connect 0.10.0.1. This release contains several new features for the MySQL connector: support for MySQL's link:/docs/connectors/mysql/#data-types[`JSON`] datatype, a new snapshot mode called link:/docs/connectors/mysql/#snapshots[`schema_only`], and link:/docs/monitoring[JMX metrics]. Also, the Debezium Docker images for Zookeeper, Kafka, and Kafka Connect have all been updated to allow optionally link:/docs/monitoring[expose JMX metrics] in these services. And, one backward-incompatible fix was made to the change event's `ts_sec` field. See the link:/docs/releases/[release notes] for specifics.
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Akshath, Chris, Vitalii, Dennis, Prannoy, and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-11-14-Debezium-0-3-5-Released.adoc
+++ b/_posts/2016-11-14-Debezium-0-3-5-Released.adoc
@@ -1,10 +1,10 @@
 ---
-tags: [ releases, mysql, docker ]
+layout: post
+title: Debezium 0.3.5 Released 
+date:   2016-11-14 10:19:59 -0600
+tags: [ releases, mysql, docker ] 
+author: rhauch
 ---
-= Debezium 0.3.5 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.5** is now available for use with Kafka Connect 0.10.0.1. This release contains several fixes for the MySQL connector and adds the ability to use with link:/docs/mysql/#multi-master-mysql/[multi-master MySQL servers] as sources. See the link:/docs/releases/[release notes] for specifics on these changes. We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
@@ -12,6 +12,8 @@ One of the fixes is signficant, and so *we strongly urge all users to upgrade to
 
 
 Thanks to Akshath, Anton, Chris, and others for their help with the release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2016-12-21-Debezium-0-3-6-Released.adoc
+++ b/_posts/2016-12-21-Debezium-0-3-6-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title:  Debezium 0.3.6 Released
+date:   2016-12-21 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.3.6 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.3.6** is now available for use with Kafka Connect 0.10.0.1. This release contains over a dozen fixes combined for the MySQL connector and MongoDB connectors. See the link:/docs/releases/[release notes] for specifics on these changes. 
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.3` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Farid, RenZhu, Dongjun, Anton, Chris, Dennis, Sharaf, Rodrigo, Tim, and others for their help with this release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == What's next
 

--- a/_posts/2017-02-07-Debezium-0-4-0-Released.adoc
+++ b/_posts/2017-02-07-Debezium-0-4-0-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title:  Debezium 0.4.0 Released
+date:   2017-02-07 10:19:59 -0600
 tags: [ releases, mysql, docker ]
+author: rhauch
 ---
-= Debezium 0.4.0 Released
-rhauch
-:awestruct-tags: [ releases, mysql, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.4.0** is now available for use with Kafka Connect 0.10.1.1. This release introduces a new link:/docs/connectors/postgresql/[PostgreSQL connector], and contains over a dozen fixes combined for the link:/docs/connectors/mongodb/[MongoDB connector] and link:/docs/connectors/mysql/[MySQL connector], including preliminar support for https://aws.amazon.com/rds/mysql/[Amazon RDS] and https://aws.amazon.com/rds/aurora/[Amazon Aurora (MySQL compatibility)]. See the link:/docs/releases/[release notes] for specifics on these changes. 
 
 We've also created https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.4` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Horia, Chris, Akshath, Ramesh, Matthias, Anton, Sagi, barton, and others for their help with this release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == What's next
 

--- a/_posts/2017-02-08-Support-for-Postgresql.adoc
+++ b/_posts/2017-02-08-Support-for-Postgresql.adoc
@@ -1,12 +1,14 @@
 ---
+layout: post
+title:  PostgreSQL support added to Debezium
+date:   2017-02-08 10:19:59 -0600
 tags: [ postgres, docker ]
+author: hchiorean
 ---
-= PostgreSQL support added to Debezium
-hchiorean
-:awestruct-tags: [ postgres, docker ]
-:awestruct-layout: blog-post
 
 With the https://debezium.io/blog/2017/02/07/Debezium-0-4-0-Released[recent Debezium release], we're happy to announce that a new **PostgreSQL connector** has been added alongside the already existing MySQL and MongoDB connectors.
+
++++<!-- more -->+++
 
 [TIP]
 ====

--- a/_posts/2017-02-22-Debezium-at-WePay.adoc
+++ b/_posts/2017-02-22-Debezium-at-WePay.adoc
@@ -1,10 +1,10 @@
 ---
-tags:  [ mysql ]
+layout: post
+title:  Streaming databases in realtime with MySQL, Debezium, and Kafka
+date:   2017-02-22 10:19:59 -0600
+tags: [ mysql ]
+author: criccomini
 ---
-= Streaming databases in realtime with MySQL, Debezium, and Kafka
-criccomini
-:awestruct-tags: [ mysql ]
-:awestruct-layout: blog-post
 
 **_This post originally appeared on the https://wecode.wepay.com/posts/streaming-databases-in-realtime-with-mysql-debezium-kafka[WePay Engineering blog]._**
 
@@ -13,6 +13,8 @@ https://en.wikipedia.org/wiki/Change_data_capture[Change data capture] has been 
 If you're wondering why you might want to stream database changes into Kafka, I highly suggest reading http://blog.christianposta.com/microservices/the-hardest-part-about-microservices-data/[The Hardest Part About Microservices: Your Data]. At WePay, we wanted to integrate our microservices and downstream datastores with each other, so every system could get access to the data that it needed. We use Kafka as our data integration layer, so we needed a way to get our database data into it.
 
 Last year, https://www.yelp.com/engineering[Yelp's engineering team] published an excellent https://engineeringblog.yelp.com/2016/11/open-sourcing-yelps-data-pipeline.html[series of posts] on their data pipeline. These included a discussion on how they https://engineeringblog.yelp.com/2016/08/streaming-mysql-tables-in-real-time-to-kafka.html[stream MySQL data into Kafka]. Their architecture involves a series of homegrown pieces of software to accomplish the task, notably https://github.com/Yelp/schematizer[schematizer] and https://github.com/Yelp/mysql_streamer[MySQL streamer]. The write-up triggered a thoughtful post on Debezium's blog about a proposed equivalent architecture using http://docs.confluent.io/3.1.1/connect/[Kafka connect], link:/[Debezium], and http://docs.confluent.io/3.1.1/schema-registry/docs/[Confluent's schema registry]. This proposed architecture is what we've been implementing at WePay, and this post describes how we leverage Debezium and Kafka connect to stream our MySQL databases into Kafka.
+
++++<!-- more -->+++
 
 ## Architecture
 

--- a/_posts/2017-03-17-Debezium-0-4-1-Released.adoc
+++ b/_posts/2017-03-17-Debezium-0-4-1-Released.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title:  Debezium 0.4.1 Released
+date:   2017-03-17 10:19:59 -0600
 tags: [ releases, mysql, mongodb, rds, docker ]
+author: rhauch
 ---
-= Debezium 0.4.1 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, rds, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.4.1** is now available for use with Kafka Connect 0.10.1.1. This release includes several fixes for the link:/docs/connectors/mongodb/[MongoDB connector] and link:/docs/connectors/mysql/[MySQL connector], including improved support for https://aws.amazon.com/rds/mysql/[Amazon RDS] and https://aws.amazon.com/rds/aurora/[Amazon Aurora (MySQL compatibility)]. See the link:/docs/releases/[release notes] for specifics on these changes. 
 
 We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.4` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Jan, Horia, David, Josh, Johan, Sanjay, Saulius, and everyone in the community for their help with this release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == What's next
 

--- a/_posts/2017-03-27-Debezium-0-5-0-Released.adoc
+++ b/_posts/2017-03-27-Debezium-0-5-0-Released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.5.0 Released
+date:   2017-03-27 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: rhauch
 ---
-= Debezium 0.5.0 Released
-rhauch
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 We're happy to announce that **Debezium 0.5.0** is now available for use with *Kafka Connect 0.10.2.0*. This release also includes a few fixes for the link:/docs/connectors/mysql/[MySQL connector]. See the link:/docs/releases/[release notes] for specifics on these changes, and be sure to check out the https://kafka.apache.org/documentation/#upgrade[Kafka documentation] for compatibility with the version of the Kafka broker that you are using.
 
@@ -15,6 +15,8 @@ Kafka Connect comes with a number of built-in SMTs that you can simply configure
 We've also added https://hub.docker.com/r/debezium/[Debezium Docker images] labelled `0.5` and `latest`, which we use in our link:/docs/tutorial/[tutorial].
 
 Thanks to Sanjay and everyone in the community for their help with this release, issues, discussions, contributions, and questions!
+
++++<!-- more -->+++
 
 == What's next
 

--- a/_posts/2017-04-26-Debezium-evolving.adoc
+++ b/_posts/2017-04-26-Debezium-evolving.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title:  Debezium Evolving
+date:   2017-04-26 10:19:59 -0600
 tags: [ community, news ]
+author: rhauch
 ---
-= Debezium Evolving
-rhauch
-:awestruct-tags: [ community, news ]
-:awestruct-layout: blog-post
 
 Just before I started the Debezium project in early 2016, https://martin.kleppmann.com[Martin Kleppmann] gave several presentations about https://martin.kleppmann.com/2015/03/04/turning-the-database-inside-out.html[turning the database inside out] and how his https://martin.kleppmann.com/2015/04/23/bottled-water-real-time-postgresql-kafka.html[Bottled Water] project demonstrated the importantance that change data capture can play in using Kafka for stream processing. Then Kafka Connect was https://www.confluent.io/blog/announcing-kafka-connect-building-large-scale-low-latency-data-pipelines/[announced], and at that point it seemed obvious to me that Kafka Connect was the foundation upon which practical and reusable change data capture can be built. As these techniques and technologies were becoming more important to https://www.redhat.com/[Red Hat], I was given the opportunity to start a new open source project and community around building great CDC connectors for a variety of databases management systems.
 
 Over the past few years, we have created Kafka Connect connectors for https://debezium.io/docs/connectors/mysql/[MySQL], then https://debezium.io/docs/connectors/mongodb/[MongoDB], and most recently https://debezium.io/docs/connectors/postgresql/[PostgreSQL]. Each were initially limited and had a number of problems and issues, but over time more and more people have tried the connectors, asked questions, answered questions, mentioned https://twitter.com/search?vertical=default&q=debezium&src=typd[Debezium on Twitter], tested connectors in their own environments, reported problems, fixed bugs, discussed limitations and potential new features, implemented enhancements and new features, improved the documentation, and wrote blog posts. Simply put, people with similar needs and interests have worked together and have formed a community. Additional connectors for https://issues.redhat.com/browse/DBZ-137[Oracle] and https://issues.redhat.com/browse/DBZ-40[SQL Server] are in the works, but could use some help to move things along more quickly.
 
 It's really exciting to see how far we've come and how the Debezium community continues to evolve and grow. And it's perhaps as good a time as any to hand the reigns over to someone else. In fact, after nearly 10 wonderful years at Red Hat, I'm making a bigger change and as of today am part of https://www.confluent.io[Confluent's] engineering team, where I expect to play a more active role in the broader https://kafka.apache.org[Kafka] community and more directly with Kafka Connect and Kafka Streams. I *definitely* plan to stay involved in the Debezium community, but will no longer be leading the project. That role will instead be filled by https://github.com/gunnarmorling/[Gunnar Morling], who's recently joined the Debezium community but has extensive experience in open source, the http://in.relation.to/gunnar-morling/[Hibernate community], and the http://beanvalidation.org[Bean Validation] specification effort. Gunnar is a great guy and an excellent developer, and will be an excellent lead for the Debezium community.
+
++++<!-- more -->+++
 
 Will the Debezium project change? To some degree it will always continue to evolve just as it has from the very beginning, and that's a healthy thing. But a lot is staying the same. Red Hat remains committed to the Debezium project, and will continue its sponsorship and community-oriented governance that has worked so well from the beginning. And just as importantly, we the community are still here and will continue building the best open source CDC connectors.
 

--- a/_posts/2017-04-27-hello-debezium.adoc
+++ b/_posts/2017-04-27-hello-debezium.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Hello Debezium!
+date:   2017-04-27 10:19:59 -0600
 tags: [ community, news ]
+author: gmorling
 ---
-= Hello Debezium!
-gmorling
-:awestruct-tags: [ community, news ]
-:awestruct-layout: blog-post
 
 When I first learned about the Debezium project last year, I was very excited about it right away.
 
@@ -19,6 +19,8 @@ As core member of the http://hibernate.org/[Hibernate team] at Red Hat, I've imp
 I've also contributed to http://hibernate.org/ogm/[Hibernate OGM] - a project which connects JPA and the world of NoSQL.
 One of the plans for OGM is to create a declarative denormalization engine for creating read models optimized for specific use cases.
 It will be very interesting to see how this plays together with the capabilities provided by Debezium.
+
++++<!-- more -->+++
 
 Currently I am serving as the lead of the http://beanvalidation.org/[Bean Validation 2.0] specification (JSR 380) as well as its reference implementation http://hibernate.org/validator/[Hibernate Validator].
 Two other projects close to my heart are http://mapstruct.org/[MapStruct] - a code generator for bean-to-bean mappings - and https://github.com/moditect/moditect[ModiTect], which is tooling for Java 9 modules and their descriptors.

--- a/_posts/2017-06-12-debezium-0-5-1-released.adoc
+++ b/_posts/2017-06-12-debezium-0-5-1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.5.1 Released
+date:   2017-06-12 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.5.1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of **Debezium 0.5.1**!
 
@@ -15,6 +15,8 @@ This release is a drop-in replacement for 0.5.0, upgrading is recommended to all
 Note that in the -- rather unlikely -- case that you happened to enable Debezium for all the system tables of MySQL,
 any configured table filters will be applied to these system tables now, too (https://issues.redhat.com/browse/DBZ-242[DBZ-242]).
 This may require an adjustment of your filters if you indeed wanted to capture all system tables but only selected non-system tables.
+
++++<!-- more -->+++
 
 Please refer to the https://github.com/debezium/debezium/blob/master/CHANGELOG.md#051[changelog] for an overview of all the 29 issues fixed in Debezium 0.5.1.
 

--- a/_posts/2017-08-17-debezium-0-5-2-is-out.adoc
+++ b/_posts/2017-08-17-debezium-0-5-2-is-out.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.5.2 Is Out
+date:   2017-08-17 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.5.2 Is Out
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of **Debezium 0.5.2**!
 
@@ -16,6 +16,8 @@ It lets you control how `NUMERIC` and `DECIMAL` columns are represented in chang
 * The MongoDB connector supports the options `database.whitelist` and `database.blacklist` now (https://issues.redhat.com/browse/DBZ-302[DBZ-302])
 * The PostgreSQL connector can deal with array-typed columns as well as with quoted identifiers for tables, schemas etc. (https://issues.redhat.com/browse/DBZ-297[DBZ-297], https://issues.redhat.com/browse/DBZ-298[DBZ-298])
 * The Debezium Docker images run on Red Hat's https://www.openshift.com/[OpenShift] cloud environment (https://issues.redhat.com/browse/DBZ-267[DBZ-267])
+
++++<!-- more -->+++
 
 Speaking about the Docker images, we've set up _nightly_ tags for the https://hub.docker.com/u/debezium/[Debezium images on Docker Hub],
 allowing you to grab the latest improvements even before an official release has been cut.

--- a/_posts/2017-09-21-debezium-0-6-0-released.adoc
+++ b/_posts/2017-09-21-debezium-0-6-0-released.adoc
@@ -1,14 +1,16 @@
 ---
+layout: post
+title:  Debezium 0.6 Is Out
+date:   2017-09-21 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.6 Is Out
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 What's better than getting http://openjdk.java.net/projects/jdk9/[Java 9]?
 Getting Java 9 and a new version of Debezium at the same time!
 So it's with great happiness that I'm announcing the release of **Debezium 0.6** today.
+
++++<!-- more -->+++
 
 == What's in it?
 

--- a/_posts/2017-09-25-streaming-to-another-database.adoc
+++ b/_posts/2017-09-25-streaming-to-another-database.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Streaming data to a downstream database
+date:   2017-09-25 10:19:59 -0600
 tags: [ mysql, postgres, smt, example ]
+author: jpechane
 ---
-= Streaming data to a downstream database
-jpechane
-:awestruct-tags: [ mysql, postgres, smt, example ]
-:awestruct-layout: blog-post
 
 In this blog post we will create a simple streaming data pipeline to continuously capture the changes in a MySQL database and replicate them in near real-time into a PostgreSQL database.
 We'll show how to do this without writing any code, but instead by using and configuring Kafka Connect, the Debezium MySQL source connector, the Confluent JDBC sink connector, and a few single message transforms (SMTs).
@@ -14,6 +14,8 @@ A recent https://www.confluent.io/blog/simplest-useful-kafka-connect-data-pipeli
 What's great about Kafka Connect is that you can mix and match connectors to move data between multiple systems.
 
 We will also demonstrate a new functionality that was released with link:2017/09/21/debezium-0-6-0-released/[Debezium 0.6.0]: a single message transform for link:/docs/configuration/event-flattening/[CDC Event Flattening].
+
++++<!-- more -->+++
 
 == Topology
 The general topology for this scenario is displayed on the following picture:

--- a/_posts/2017-10-26-debezium-0-6-1-released.adoc
+++ b/_posts/2017-10-26-debezium-0-6-1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.6.1 Is Released
+date:   2017-10-26 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.6.1 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 Just shy of a month after the 0.6.0 release, I'm happy to announce the release of **Debezium 0.6.1**!
 
@@ -12,6 +12,8 @@ This release contains several bugfixes, dependency upgrades and a new option for
 We also expanded the set of Docker images and Docker Compose files accompanying link:/docs/tutorial/[our tutorial], so you can run it now with all the databases we support.
 
 Let's take a closer look at some of the changes.
+
++++<!-- more -->+++
 
 == New connector option for controlling BIGINT UNSIGNED representation
 

--- a/_posts/2017-11-11-debezium-at-devoxx-belgium.adoc
+++ b/_posts/2017-11-11-debezium-at-devoxx-belgium.adoc
@@ -1,16 +1,18 @@
 ---
+layout: post
+title:  Debezium at Devoxx Belgium
+date:   2017-11-11 10:19:59 -0600
 tags: [ introduction, presentation ]
+author: jpechane
 ---
-= Debezium at Devoxx Belgium
-jpechane
-:awestruct-tags: [ introduction, presentation ]
-:awestruct-layout: blog-post
 
 Debezium's project lead https://twitter.com/gunnarmorling[Gunnar Morling] gave a few talks during recent https://cfp.devoxx.be/2017/index.html[Devoxx Belgium 2017].
 One of his talks was dedicated to Debezium and change data capture in general.
 
 If you are interested in those topics and you want to obtain a fast and simple introduction to it, do not hesitate and watch the talk.
 Batteries and demo included!
+
++++<!-- more -->+++
 
 ++++
 <div class="responsive-video">

--- a/_posts/2017-11-15-debezium-0-6-2-released.adoc
+++ b/_posts/2017-11-15-debezium-0-6-2-released.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title:  Debezium 0.6.2 Is Released
+date:   2017-11-15 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: jpechane
 ---
-= Debezium 0.6.2 Is Released
-jpechane
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 We are accelerating! Three weeks after the 0.6.1 release, the Debezium team is bringing **Debezium 0.6.2** to you!
 
 This release revolves mostly around bug fixes, but there are a few new features, too.
 Let's take a closer look at some of the changes.
+
++++<!-- more -->+++
 
 == PostgreSQL Connector
 

--- a/_posts/2017-12-15-debezium-0-7-0-released.adoc
+++ b/_posts/2017-12-15-debezium-0-7-0-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.0 Is Released
+date:   2017-12-15 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: jpechane
 ---
-= Debezium 0.7.0 Is Released
-jpechane
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 It's not Christmas yet, but we already got a present for you: Debezium  *0.7.0* is here, full of new features as well as many bug fixes!
 A big thank you goes out to all the community members who contributed to this release.
@@ -16,6 +16,8 @@ e.g. if the previous mapping could have caused potential value losses.
 Please see below for the details and also make sure to check out the link:/docs/releases/#release-0-7-0[full change log] which describes these changes in detail.
 
 Now let's take a closer look at some of new features.
+
++++<!-- more -->+++
 
 == Based on Apache Kafka 1.0
 

--- a/_posts/2017-12-20-debezium-0-7-1-released.adoc
+++ b/_posts/2017-12-20-debezium-0-7-1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.1 Is Released
+date:   2017-12-20 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: jpechane
 ---
-= Debezium 0.7.1 Is Released
-jpechane
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 Just last few days before Christmas we are releasing Debezium  *0.7.1*!
 This is a bugfix release that fixes few annoying issues that were found during first rounds of use of Debezium 0.7 by our community.
@@ -16,6 +16,8 @@ Suraj Savita (and others) has found an issue when our code failed to https://iss
 We are outsmarted by the JDBC driver internals and included a distinct plugin decoder name https://issues.redhat.com/browse/DBZ-517[wal2json_rds] that bypasses detection routine and by default expects it runs against Amazon RDS instance. This mode should be used only with RDS instances.
 
 We have also gathered feedback from first tries to run with Amazon RDS and included link:/docs/connectors/postgresql/#amazon-rds[a short section] in our documentation on this topic.
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2018-01-17-streaming-to-elasticsearch.adoc
+++ b/_posts/2018-01-17-streaming-to-elasticsearch.adoc
@@ -1,11 +1,11 @@
 ---
-tags: [ mysql, postgres, elasticsearch, smt, example, featured ]
+layout: post
+title:  Streaming Data Changes from Your Database to Elasticsearch
+date:   2018-01-17 10:19:59 -0600
+tags: [ mysql, postgres, elasticsearch, smt, example ]
 featured: true
+author: jpechane
 ---
-= Streaming Data Changes from Your Database to Elasticsearch
-jpechane
-:awestruct-tags: [ mysql, postgres, elasticsearch, smt, example, featured ]
-:awestruct-layout: blog-post
 
 We wish all the best to the Debezium community for 2018!
 
@@ -13,6 +13,8 @@ While we're working on the 0.7.2 release, we thought we'd publish another post d
 We have seen how to set up a change data stream to a downstream database link:/blog/2017/09/25/streaming-to-another-database/[a few weeks ago].
 In this blog post we will follow the same approach to stream the data to an https://www.elastic.co/[Elasticsearch] server to leverage its excellent capabilities for full-text search on our data.
 But to make the matter a little bit more interesting, we will stream the data to both, a PostgreSQL database and Elasticsearch, so we will optimize access to the data via the SQL query language as well as via full-text search.
+
++++<!-- more -->+++
 
 == Topology
 Here's a diagram that shows how the data is flowing through our distributed system.

--- a/_posts/2018-01-25-debezium-0-7-2-released.adoc
+++ b/_posts/2018-01-25-debezium-0-7-2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.2 Is Released
+date:   2018-01-25 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.7.2 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.7.2*!
 
@@ -26,6 +26,8 @@ https://github.com/sairam881990[Sairam Polavarapu] and
 https://github.com/tombentley[Tom Bentley].
 
 Now let's take a closer look at some of new features.
+
++++<!-- more -->+++
 
 == MySQL Connector
 

--- a/_posts/2018-02-15-debezium-0-7-3-released.adoc
+++ b/_posts/2018-02-15-debezium-0-7-3-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.3 Is Released
+date:   2018-02-15 10:19:59 -0600
 tags: [ releases, mysql, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.7.3 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, docker ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *0.7.3*!
 
@@ -14,6 +14,8 @@ When upgrading from earlier versions,
 please check out the link:/docs/releases/[release notes] of all versions between the one your're currently on and 0.7.3 in order to learn about any steps potentially required for upgrading.
 
 Let's take a closer look at some of the new features.
+
++++<!-- more -->+++
 
 == All Connectors
 

--- a/_posts/2018-03-07-debezium-0-7-4-released.adoc
+++ b/_posts/2018-03-07-debezium-0-7-4-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.4 Is Released
+date:   2018-03-07 10:19:59 -0600
 tags: [ releases, mysql, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.7.4 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.7.4*!
 
@@ -12,6 +12,8 @@ Continuing the 0.7 release line, this new version brings several bug fixes and a
 We recommend this upgrade to all users.
 When upgrading from earlier versions,
 please check out the link:/docs/releases/[release notes] of all versions between the one you're currently on and 0.7.4 in order to learn about any steps potentially required for upgrading.
+
++++<!-- more -->+++
 
 == New features
 

--- a/_posts/2018-03-08-creating-ddd-aggregates-with-debezium-and-kafka-streams.adoc
+++ b/_posts/2018-03-08-creating-ddd-aggregates-with-debezium-and-kafka-streams.adoc
@@ -1,11 +1,11 @@
 ---
+layout: post
+title:  Creating DDD aggregates with Debezium and Kafka Streams
+date:   2018-03-08 10:19:59 -0600
 tags: [ discussion, examples ]
 featured: true
+author: hpgrahsl,gmorling
 ---
-= Creating DDD aggregates with Debezium and Kafka Streams
-hpgrahsl,gmorling
-:awestruct-tags: [ discussion, examples, featured ]
-:awestruct-layout: blog-post
 
 Microservice-based architectures can be considered an industry trend and are thus
 often found in enterprise applications lately. One possible way to keep data
@@ -19,6 +19,8 @@ between data sources and data sinks. Such a scenario can be implemented based on
 and https://kafka.apache.org/[Apache Kafka] with relative ease and effectively no coding.
 
 As an example, consider the following microservice-based architecture of an order management system:
+
++++<!-- more -->+++
 
 [.centered-image.responsive-image]
 ====

--- a/_posts/2018-03-16-note-on-database-history-topic-configuration.adoc
+++ b/_posts/2018-03-16-note-on-database-history-topic-configuration.adoc
@@ -1,14 +1,16 @@
 ---
+layout: post
+title:  A Note On Database History Topic Configuration
+date:   2018-03-16 10:19:59 -0600
 tags: [ mysql ]
+author: gmorling
 ---
-= A Note On Database History Topic Configuration
-gmorling
-:awestruct-tags: [ mysql ]
-:awestruct-layout: blog-post
 
 A user of the Debezium connector for MySQL informed us about a potential issue with the configuration of the connector's internal database history topic,
 which may cause the deletion of parts of that topic (https://issues.redhat.com/browse/DBZ-663[DBZ-663]).
 Please continue reading if you're using the Debezium MySQL connector in versions 0.7.3 or 0.7.4.
+
++++<!-- more -->+++
 
 == What is the issue about?
 

--- a/_posts/2018-03-20-debezium-0-7-5-released.adoc
+++ b/_posts/2018-03-20-debezium-0-7-5-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.7.5 Is Released
+date:   2018-03-20 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, docker ]
+author: gmorling
 ---
-= Debezium 0.7.5 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.7.5*!
 
@@ -16,6 +16,8 @@ Please see the link:/2018/03/16/note-on-database-history-topic-configuration/[de
 Together with this, we released a couple of other fixes and improvements.
 Thanks to https://github.com/maver1ck[Maciej Brynski], the performance of the link:/docs/configuration/topic-routing/[logical table routing SMT] has been improved significantly (https://issues.redhat.com/browse/DBZ-655[DBZ-655]).
 Another fix contributed by Maciej is for https://issues.redhat.com/browse/DBZ-646[DBZ-646] which lets the MySQL connector handle `CREATE TABLE` statements for the TokuDB storage engine now.
+
++++<!-- more -->+++
 
 And we got some more bugfixes by our fantastic community:
 Long-term community member https://github.com/pgoranss[Peter Goransson] fixed an issue about the snapshot JMX metrics of the MySQL connector,

--- a/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
+++ b/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Querying Debezium Change Data Events With KSQL
+date:   2018-05-24 10:19:59 -0600
 tags: [ mysql, ksql, example ]
+author: jpechane
 ---
-= Querying Debezium Change Data Events With KSQL
-jpechane
-:awestruct-tags: [ mysql, ksql, example ]
-:awestruct-layout: blog-post
 
 _Last updated at Nov 21st 2018 (adjusted to new KSQL Docker images)_.
 
@@ -14,6 +14,8 @@ In this post, we are going to try out KSQL querying with data change events gene
 
 As a source of data we will use the database and setup from our link:/docs/tutorial/[tutorial].
 The result of this exercise should be similar to the recent link:/blog/2018/03/08/creating-ddd-aggregates-with-debezium-and-kafka-streams/[post] about aggregation of events into link:https://martinfowler.com/bliki/DDD_Aggregate.html[domain driven aggregates].
+
++++<!-- more -->+++
 
 == Entity diagram
 

--- a/_posts/2018-06-21-debezium-0-8-0-beta1-released.adoc
+++ b/_posts/2018-06-21-debezium-0-8-0-beta1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.8.0.Beta1 Is Released
+date:   2018-06-21 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.8.0.Beta1 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
-:awestruct-layout: blog-post
 
 It's with great excitement that I'm announcing the release of Debezium *0.8.0.Beta1*!
 
@@ -19,6 +19,8 @@ going forward we may do one or more Beta and CR ("candidate release") releases b
 This will allow us to get feedback from the community early on,
 while still completing and polishing specific features.
 Final (stable) releases will be named like 0.8.0.Final etc.
+
++++<!-- more -->+++
 
 This release would not have been possible without our outstanding community;
 a huge "thank you" goes out to the following open source enthusiasts who all contributed to the new version:

--- a/_posts/2018-07-04-debezium-0-8-0-cr1-released.adoc
+++ b/_posts/2018-07-04-debezium-0-8-0-cr1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.8.0.CR1 Is Released
+date:   2018-07-04 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.8.0.CR1 Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
-:awestruct-layout: blog-post
 
 A fantastic Independence Day to all the Debezium users in the U.S.!
 But that's not the only reason to celebrate: it's also with great happiness that I'm announcing the release of Debezium *0.8.0.CR1*!
@@ -19,6 +19,8 @@ As announced recently, for 0.8 the legacy parser will remain the default impleme
 but you are strongly encouraged to test out the new one
 (by setting the connector option `ddl.parser.mode` to `antlr`) and report any findings you may have.
 We've planned to switch to the new implementation by default in Debezium 0.9.
+
++++<!-- more -->+++
 
 In terms of new features, the CR1 release brings support for `CITEXT` columns in the Postgres connector (https://issues.redhat.com/browse/DBZ-762[DBZ-762]).
 All the relational connectors support it now to convey the original name and length of captured columns using schema parameters in the emitted change messages (https://issues.redhat.com/browse/DBZ-644[DBZ-644]).

--- a/_posts/2018-07-12-debezium-0-8-0-final-released.adoc
+++ b/_posts/2018-07-12-debezium-0-8-0-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.8 Final Is Released
+date:   2018-07-12 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.8 Final Is Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, oracle, docker ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *0.8.0.Final*!
 
@@ -21,6 +21,8 @@ apart from further improvements to the Oracle connector (https://issues.redhat.c
 when doing a snapshot, it will now expose information about the processed rows via JMX (https://issues.redhat.com/browse/DBZ-789[DBZ-789]), which is very handy when snapshotting larger tables.
 
 Please take a look at the link:/docs/releases/#release-0-8-0-final[change log] for the complete list of changes in 0.8.0.Final and general upgrade notes.
+
++++<!-- more -->+++
 
 == What's next?
 

--- a/_posts/2018-07-19-advantages-of-log-based-change-data-capture.adoc
+++ b/_posts/2018-07-19-advantages-of-log-based-change-data-capture.adoc
@@ -1,11 +1,11 @@
 ---
+layout: post
+title:  Five Advantages of Log-Based Change Data Capture
+date:   2018-07-19 10:19:59 -0600
 tags: [ discussion ]
 featured: true
+author: gmorling
 ---
-= Five Advantages of Log-Based Change Data Capture
-gmorling
-:awestruct-tags: [ discussion, featured ]
-:awestruct-layout: blog-post
 
 Yesterday I had the opportunity to present Debezium and the idea of change data capture (CDC) to the https://twitter.com/JUG_DA/status/1019634941020332032[Darmstadt Java User Group].
 It was a great evening with lots of interesting discussions and questions.
@@ -19,6 +19,8 @@ As this wasn't the first time this question came up, I thought I could provide a
 That way I'll be able to refer to this post in the future, should the question come up again :)
 
 So without further ado, here's my list of five advantages of log-based CDC over polling-based approaches.
+
++++<!-- more -->+++
 
 All Data Changes Are Captured:: By reading the database's log, you get the complete list of all data changes in their exact order of application.
 This is vital for many use cases where you are interested in the complete history of record changes.

--- a/_posts/2018-07-26-debezium-0-9-0-alpha1-released.adoc
+++ b/_posts/2018-07-26-debezium-0-9-0-alpha1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9 Alpha1 and 0.8.1 Released
+date:   2018-07-26 10:19:59 -0600
 tags: [ releases, postgres, oracle, docker, sqlserver ]
+author: gmorling
 ---
-= Debezium 0.9 Alpha1 and 0.8.1 Released
-gmorling
-:awestruct-tags: [ releases, postgres, oracle, docker, sqlserver ]
-:awestruct-layout: blog-post
 
 Just two weeks after the Debezium 0.8 release, I'm very happy to announce the release of Debezium *0.9.0.Alpha1*!
 
@@ -21,6 +21,8 @@ Please take a look at the link:/docs/releases/#release-0-9-0-alpha1[change log] 
 _Note:_ [.line-through]#At the time of writing (2018-07-26), the release artifacts (connector archives) are available on http://central.maven.org/maven2/io/debezium/[Maven Central].
 We'll upload the Docker images for 0.9.0.Alpha1 to https://hub.docker.com/u/debezium/[Docker Hub] as soon as possible.#
 The Docker images are already uplodaded and ready for use under tags `0.9.0.Alpha1` and rolling `0.9`.
+
++++<!-- more -->+++
 
 == SQL Server Connector
 

--- a/_posts/2018-08-30-debezium-0-8-2-released.adoc
+++ b/_posts/2018-08-30-debezium-0-8-2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.8.2 Released
+date:   2018-08-30 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.8.2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 The Debezium team is back from summer holidays and we're happy to announce the release of Debezium *0.8.2*!
 
@@ -21,6 +21,8 @@ Also the link:/docs/connectors/mongodb/[MongoDB connector] saw a bug fix (https:
 More a useful improvement rather than a bug fix is the link:/docs/connectors/postgresql/[Postgres connector's] capability to add the table, schema and database names to the `source` block of emitted CDC events (https://issues.redhat.com/browse/DBZ-866[DBZ-866]).
 
 Thanks a lot to community members https://github.com/jchipmunk[Andrey Pustovetov], https://github.com/CliffWheadon[Cliff Wheadon] and https://github.com/oripwk[Ori Popowski] for their contributions to this release!
+
++++<!-- more -->+++
 
 == What's next?
 

--- a/_posts/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
+++ b/_posts/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Streaming MySQL Data Changes to Amazon Kinesis
+date:   2018-08-30 10:19:59 -0600
 tags: [ discussion, examples ]
+author: gmorling
 ---
-= Streaming MySQL Data Changes to Amazon Kinesis
-gmorling
-:awestruct-tags: [ discussion, examples ]
-:awestruct-layout: blog-post
 
 Most of the times Debezium is used to stream data changes into http://kafka.apache.org/[Apache Kafka].
 What though if you're using another streaming platform such as https://pulsar.incubator.apache.org/[Apache Pulsar] or a cloud-based solution such as https://aws.amazon.com/kinesis/[Amazon Kinesis], https://azure.microsoft.com/services/event-hubs/[Azure Event Hubs] and the like?
@@ -13,6 +13,8 @@ Can you still benefit from Debezium's powerful change data capture (CDC) capabil
 Turns out, with just a bit of glue code, you can!
 In the following we'll discuss how to use Debezium to capture changes in a MySQL database and stream the change events into Kinesis,
 a fully-managed data streaming service available on the Amazon cloud.
+
++++<!-- more -->+++
 
 == Introducing the Debezium Embedded Engine
 

--- a/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
+++ b/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.8.3.Final Released
+date:   2018-09-19 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.8.3.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, docker ]
-:awestruct-layout: blog-post
 
 As temperatures are cooling off, the Debezium team is getting into full swing again and we're happy to announce the release of Debezium *0.8.3.Final*!
 
@@ -16,6 +16,8 @@ The link:/docs/connectors/postgresql/[Postgres connector] saw a huge improvement
 The user reporting this issue had nearly 200K entries in pg_catalog.pg_type, and due to an N + 1 SELECT issue within the Postgres driver itself, this caused the connector to take 24 minutes to start.
 By using a custom query for obtaining the type metadata, we were able to cut down this time to 5 seconds!
 Right now we're working with the maintainers of the Postgres driver to get this issue fixed upstream, too.
+
++++<!-- more -->+++
 
 == More Flexible Propagation of DELETEs
 

--- a/_posts/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
+++ b/_posts/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
@@ -1,11 +1,11 @@
 ---
+layout: post
+title:  Materializing Aggregate Views With Hibernate and Debezium
+date:   2018-09-20 10:19:59 -0600
 tags: [ discussion, examples ]
 featured: true
+author: gmorling
 ---
-= Materializing Aggregate Views With Hibernate and Debezium
-gmorling
-:awestruct-tags: [ discussion, examples, featured ]
-:awestruct-layout: blog-post
 
 Updating external full text search indexes (e.g. https://www.elastic.co/products/elasticsearch[Elasticsearch]) after data changes is a very popular use case for change data capture (CDC).
 
@@ -23,6 +23,8 @@ allowing you to efficiently search for customers based on their address.
 
 Following up to the link:/blog/2018/03/08/creating-ddd-aggregates-with-debezium-and-kafka-streams/[KStreams-based solution] to this we described recently,
 we'd like to present in this post an alternative for materializing such aggregate views driven by the application layer.
+
++++<!-- more -->+++
 
 == Overview
 

--- a/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
+++ b/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.0.Alpha2 Released
+date:   2018-10-04 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.0.Alpha2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.9.0.Alpha2*!
 
@@ -32,6 +32,8 @@ https://github.com/sagarrao[Sagar Rao] and
 https://github.com/SyedMuhammadSufyian[Syed Muhammad Sufyian]
 for their contributions to this release.
 We salute you!
+
++++<!-- more -->+++
 
 == Kafka Upgrade
 

--- a/_posts/2018-11-22-debezium-0-9-0-beta1-released.adoc
+++ b/_posts/2018-11-22-debezium-0-9-0-beta1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.0.Beta1 Released
+date:   2018-11-22 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.0.Beta1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.9.0.Beta1*!
 Oh, and to those of you who are celebrating it -- Happy Thanksgiving!
@@ -14,6 +14,8 @@ This new Debezium release comes with several great improvements to our work-in-p
 * Initial snapshots can be done using the `snapshot` isolation level if enabled in the DB (https://issues.redhat.com/browse/DBZ-941[DBZ-941])
 * Changes to the structures of captured tables after the connector has been set up are supported now (https://issues.redhat.com/browse/DBZ-812[DBZ-812])
 * New connector option `decimal.handling.mode` (https://issues.redhat.com/browse/DBZ-953[DBZ-953]) and pass-through of any `database.*` option to the JDBC driver (https://issues.redhat.com/browse/DBZ-964[DBZ-964])
+
++++<!-- more -->+++
 
 Besides that, we spent some time on supporting the latest versions of the different databases.
 The Debezium connectors now support Postgres 11 (https://issues.redhat.com/browse/DBZ-955[DBZ-955]) and MongoDB 4.0 (https://issues.redhat.com/browse/DBZ-974[DBZ-974]).

--- a/_posts/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
+++ b/_posts/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
@@ -1,11 +1,11 @@
 ---
-tags: [ discussion, examples, featured ]
+layout: post
+title:  Automating Cache Invalidation With Change Data Capture
+date:   2018-12-05 10:19:59 -0600
+tags: [ discussion, examples ]
 featured: true
+author: gmorling
 ---
-= Automating Cache Invalidation With Change Data Capture
-gmorling
-:awestruct-tags: [ discussion, examples, featured ]
-:awestruct-layout: blog-post
 
 The https://docs.jboss.org/hibernate/stable/orm/userguide/html_single/Hibernate_User_Guide.html#caching-config[second-level cache] of Hibernate ORM / JPA is a proven and efficient way to increase application performance:
 caching read-only or rarely modified entities avoids roundtrips to the database,
@@ -26,6 +26,8 @@ by employing Debezium and its link:/blog/2018/07/19/advantages-of-log-based-chan
 This allows to invalidate affected cache entries in near-realtime,
 without the risk of stale data due to missed changes.
 If an entry has been evicted from the cache, Hibernate ORM will load the latest version of the entity from the database the next time is requested.
+
++++<!-- more -->+++
 
 == The Example Application
 

--- a/_posts/2018-12-19-debezium-0-9-0-beta2-released.adoc
+++ b/_posts/2018-12-19-debezium-0-9-0-beta2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.0.Beta2 Released
+date:   2018-12-19 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.0.Beta2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 With only a few days left for the year, it's about time for another Debezium release;
 so it's with great pleasure that I'm announcing Debezium *0.9.0.Beta2*!
@@ -22,6 +22,8 @@ https://github.com/renatomefi[Renato Mefi], https://github.com/tautautau[Tautvyd
 https://github.com/wscheep[Wout Scheepers] and https://github.com/wangzheng422[Zheng Wang]!
 
 In the following, let's take a closer look at some of the changes coming with the 0.9 Beta2 release.
+
++++<!-- more -->+++
 
 == Monitoring and Metrics for the SQL Server and Oracle Connectors
 

--- a/_posts/2019-01-28-debezium-0-9-0-cr1-released.adoc
+++ b/_posts/2019-01-28-debezium-0-9-0-cr1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.0.CR1 Released
+date:   2019-01-28 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.0.CR1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 Reaching the home stretch towards Debezium 0.9, it's with great pleasure that I'm announcing the first release of Debezium in 2019, *0.9.0.CR1*!
 
@@ -14,6 +14,8 @@ the connector comes with greatly improved performance and has received a fair nu
 Other changes include a new interface for event handlers of Debezium's link:/docs/embedded/[embedded engine],
 which allows for bulk handling of change events, an option to export the scale of numeric columns as schema parameter,
 as well as a wide range of bug fixes for the Debezium connectors for MySQL, Postgres and Oracle.
+
++++<!-- more -->+++
 
 == SQL Server Connector Improvements
 

--- a/_posts/2019-02-05-debezium-0-9-0-final-released.adoc
+++ b/_posts/2019-02-05-debezium-0-9-0-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.0.Final Released
+date:   2019-02-05 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.0.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 I'm delighted to announce the release of Debezium *0.9 Final*!
 
@@ -18,6 +18,8 @@ Debezium 0.9 comes with a brand new link:/docs/connectors/sqlserver/[connector f
 lots of new features and improvements for the existing connectors,
 updates to the latest versions of Apache Kafka and the supported databases
 as well as a wide range of bug fixes.
+
++++<!-- more -->+++
 
 Some key features of the release besides the aforementioned CDC connector for SQL Server are:
 

--- a/_posts/2019-02-13-debezium-0-9-1-final-released.adoc
+++ b/_posts/2019-02-13-debezium-0-9-1-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.1.Final Released
+date:   2019-02-13 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.1.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 Quickly following up to last week's release of Debezium 0.9, it's my pleasure today to announce the release of Debezium *0.9.1.Final*!
 
@@ -16,6 +16,8 @@ which can help to significantly increase through-put and reduce memory consumpti
 
 The MySQL connector supports `GENERATED` columns now with the new Antlr-based DDL parser (https://issues.redhat.com/browse/DBZ-1123[DBZ-1123]),
 and for the Postgres connector the handling of primary key column definition changes was improved (https://issues.redhat.com/browse/DBZ-997[DBZ-997]).
+
++++<!-- more -->+++
 
 In terms of new features, there is a new container image provided on Docker Hub now:
 the https://hub.docker.com/r/debezium/tooling[debezium/tooling] image contains a couple of open-source CLI tools

--- a/_posts/2019-02-13-debezium-webinar-at-devnation-live.adoc
+++ b/_posts/2019-02-13-debezium-webinar-at-devnation-live.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium at DevNation Live
+date:   2019-02-13 10:19:59 -0600
 tags: [ introduction, presentation ]
+author: gmorling
 ---
-= Debezium at DevNation Live
-gmorling
-:awestruct-tags: [ introduction, presentation ]
-:awestruct-layout: blog-post
 
 Last week I had the pleasure to do a https://developers.redhat.com/videos/youtube/QYbXDp4Vu-8/[webinar on change data streaming patterns for microservices] with the fabulous Burr Sutter at DevNation Live.
 
@@ -14,6 +14,8 @@ running on OpenShift.
 The demo begins at 12 min 40 into the recording.
 
 Enjoy!
+
++++<!-- more -->+++
 
 ++++
 <div class="responsive-video">

--- a/_posts/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
+++ b/_posts/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
@@ -1,20 +1,19 @@
 ---
+layout: post
+title:  Reliable Microservices Data Exchange With the Outbox Pattern
+date:   2019-02-19 10:19:59 -0600
 tags: [ discussion, examples, microservices, apache-kafka ]
 featured: true
+author: gmorling
 ---
-= Reliable Microservices Data Exchange With the Outbox Pattern
-gmorling
-:awestruct-tags: [ discussion, examples, microservices, apache-kafka, featured ]
-:awestruct-layout: blog-post
 
-[role="teaser"]
---
 As part of their business logic, microservices often do not only have to update their own local data store,
 but they also need to notify other services about data changes that happened.
 The outbox pattern describes an approach for letting services execute these two tasks in a safe and consistent manner;
 it provides source services with instant "read your own writes" semantics,
 while offering reliable, eventually consistent data exchange across service boundaries.
---
+
++++<!-- more -->+++
 
 _Update (13 Sept. 2019):_ To simplify usage of the outbox pattern, Debezium now provides a ready-to-use link:/documentation/reference/0.9/configuration/outbox-event-router.html[SMT for routing outbox events]. The custom SMT discussed in this blog post is not needed any longer.
 

--- a/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
+++ b/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.2.Final Released
+date:   2019-02-25 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, docker ]
+author: gmorling
 ---
-= Debezium 0.9.2.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, docker ]
-:awestruct-layout: blog-post
 
 The Debezium team is happy to announce the release of Debezium *0.9.2.Final*!
 
@@ -12,6 +12,8 @@ This is mostly a bug-fix release and a drop-in replacement for earlier Debezium 
 Overall, https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%200.9.2.Final[18 issues] were resolved.
 
 A couple of fixes relate to the link:/docs/connectors/postgresql/[Debezium Postgres connector]:
+
++++<!-- more -->+++
 
 * When not using `REPLICA IDENTITY FULL`, certain data types could trigger exceptions for update or delete events; those are fixed now
 (https://issues.redhat.com/browse/DBZ-1141[DBZ-1141], https://issues.redhat.com/browse/DBZ-1149[DBZ-1149])

--- a/_posts/2019-03-14-debezium-meets-quarkus.adoc
+++ b/_posts/2019-03-14-debezium-meets-quarkus.adoc
@@ -1,18 +1,17 @@
 ---
+layout: post
+title:  Debezium meets Quarkus
+date:   2019-03-14 10:19:59 -0600
 tags: [ quarkus, examples, microservices, apache-kafka ]
+author: jpechane
 ---
-= Debezium meets Quarkus
-jpechane
-:awestruct-tags: [ quarkus, examples, microservices, apache-kafka ]
-:awestruct-layout: blog-post
 
-[role="teaser"]
---
 Last week's announcement of https://quarkus.io/[Quarkus] sparked a great amount of interest in the Java community:
 crafted from the best of breed Java libraries and standards, it allows to build Kubernetes-native applications based on GraalVM & OpenJDK HotSpot.
 In this blog post we are going to demonstrate how a Quarkus-based microservice can consume Debezium's data change events via Apache Kafka.
 For that purpose, we'll see what it takes to convert the shipment microservice from our recent post about the link:2019/02/19/reliable-microservices-data-exchange-with-the-outbox-pattern[outbox pattern] into Quarkus-based service.
---
+
++++<!-- more -->+++
 
 Quarkus is a Java stack designed for the development of cloud-native applications based on the Java platform.
 It combines and tightly integrates mature libraries such Hibernate ORM, Vert.x, Netty, RESTEasy and Apache Camel as well as the APIs from the https://microprofile.io/[Eclipse MicroProfile] initiative,

--- a/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
+++ b/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.9.3.Final Released
+date:   2019-03-26 10:19:59 -0600
 tags: [ releases, mysql, mongodb, postgres, sqlserver, docker ]
+author: jpechane
 ---
-= Debezium 0.9.3.Final Released
-jpechane
-:awestruct-tags: [ releases, mysql, mongodb, postgres, sqlserver, docker ]
-:awestruct-layout: blog-post
 
 The Debezium team is happy to announce the release of Debezium *0.9.3.Final*!
 
@@ -13,6 +13,8 @@ Overall, https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVe
 
 [NOTE]
 Container images will be released with a small delay due to some Docker Hub configuration issues.
+
++++<!-- more -->+++
 
 == New Features
 

--- a/_posts/2019-04-11-debezium-0-9-4-final-released.adoc
+++ b/_posts/2019-04-11-debezium-0-9-4-final-released.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title:  Debezium 0.9.4.Final Released
+date:   2019-04-11 10:19:59 -0600
 tags: [ releases, mysql, postgres, docker ]
+author: gmorling
 ---
-= Debezium 0.9.4.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.9.4.Final*!
 
 This is a drop-in replacement for earlier Debezium 0.9.x versions, containing mostly bug fixes and some improvements related to metrics.
 Overall, https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%200.9.4.Final[17 issues] were resolved.
+
++++<!-- more -->+++
 
 == MySQL Connector Improvements
 

--- a/_posts/2019-04-18-hello-debezium.adoc
+++ b/_posts/2019-04-18-hello-debezium.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium's Team Grows
+date:   2019-04-18 10:19:59 -0600
 tags: [ community, news ]
+author: ccranfor
 ---
-= Debezium's Team Grows
-ccranfor
-:awestruct-tags: [ community, news ]
-:awestruct-layout: blog-post
 
 Hello everyone, my name is Chris Cranford and I recently joined the Debezium team.
 

--- a/_posts/2019-05-06-debezium-0-9-5-final-released.adoc
+++ b/_posts/2019-05-06-debezium-0-9-5-final-released.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title:  Debezium 0.9.5.Final Released
+date:   2019-05-06 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.9.5.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.9.5.Final*!
 
 This is a recommended update for all users of earlier versions; besides bug fixes also a few new features are provide.
 The release contains https://issues.redhat.com/issues/?jql=project+%3D+DBZ+AND+fixVersion+%3D+0.9.5.Final[18 resolved issues] overall.
+
++++<!-- more -->+++
 
 == Apache Kafka Update and New Features
 

--- a/_posts/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
+++ b/_posts/2019-05-23-tutorial-using-debezium-connectors-with-apache-pulsar.adoc
@@ -1,10 +1,10 @@
 ---
-tags: [ community, news ]
+layout: post
+title:  Tutorial for Using Debezium Connectors With Apache Pulsar
+date:   2019-05-23 10:19:59 -0600
+tags: [ discussion, examples ]
+author: jiazhai, StreamNative
 ---
-= Tutorial for Using Debezium Connectors With Apache Pulsar
-jiazhai, StreamNative
-:awestruct-tags: [ discussion, examples  ]
-:awestruct-layout: blog-post
 
 **_This is a guest post by Apache Pulsar PMC Member and Committer Jia Zhai._**
 
@@ -13,6 +13,8 @@ http://pulsar.apache.org[Apache Pulsar] includes a set of https://pulsar.apache.
 
 As of version 2.3.0, Pulsar IO comes with support for the http://pulsar.apache.org/docs/en/2.3.0/io-cdc-debezium[Debezium source connectors] out of the box, so you can leverage Debezium to stream changes from your databases into Apache Pulsar.
 This tutorial walks you through setting up the Debezium connector for MySQL with Pulsar IO.
+
++++<!-- more -->+++
 
 ## Tutorial Steps
 This tutorial is similar to the https://debezium.io/docs/tutorial[Debezium tutorial], except that storage of event streams is changed from Kafka to Pulsar.

--- a/_posts/2019-05-29-debezium-0-10-0-alpha1-released.adoc
+++ b/_posts/2019-05-29-debezium-0-10-0-alpha1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Alpha1 "Spring Clean-Up" Edition Released
+date:   2019-05-29 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.10.0.Alpha1 "Spring Clean-Up" Edition Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *0.10.0.Alpha1*!
 
@@ -15,6 +15,8 @@ we've planned to remove a few deprecated features and to streamline some details
 This means that upgrading to Debezium 0.10 from earlier versions might take a bit more planning and consideration compared to earlier upgrades,
 depending on your usage of features and options already marked as deprecated in 0.9 and before.
 But no worries, we're describing all changes in great detail in this blog post and the https://debezium.io/docs/releases/#release-0-10-0-alpha1[release notes].
+
++++<!-- more -->+++
 
 == Why?
 

--- a/_posts/2019-06-03-debezium-0-10-0-alpha2-released.adoc
+++ b/_posts/2019-06-03-debezium-0-10-0-alpha2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Alpha2 Released
+date:   2019-06-03 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: jpechane
 ---
-= Debezium 0.10.0.Alpha2 Released
-jpechane
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 Release early, release often -- Less than a week since the Alpha1 we are announcing the release of Debezium *0.10.0.Alpha2*!
 
@@ -12,6 +12,8 @@ This is an incremental release that completes some of the tasks started in the A
 
 The change in the logic of the `snapshot` field has been delivered (https://issues.redhat.com/browse/DBZ-1295[DBZ-1295]) as outlined in link:2019/05/29/debezium-0-10-0-alpha1-released/#outlook[the last announcement].
 All connectors now provide information which of the records is the last one in the snapshot phase so that downstream consumers can react to this.
+
++++<!-- more -->+++
 
 Apache ZooKeeper was upgraded to version 3.4.14 to fix a security vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2019-0201[CVE-2019-0201]).
 

--- a/_posts/2019-06-05-debezium-newsletter-01-2019.adoc
+++ b/_posts/2019-06-05-debezium-newsletter-01-2019.adoc
@@ -1,13 +1,15 @@
 ---
+layout: post
+title:  Debezium's Newsletter 01/2019
+date:   2019-06-05 10:19:59 -0600
 tags: [ community, news, newsletter ]
+author: ccranfor
 ---
-= Debezium's Newsletter 01/2019
-ccranfor
-:awestruct-tags: [ community, news, newsletter ]
-:awestruct-layout: blog-post
 
 Welcome to the first edition of the Debezium community newsletter in which we share blog posts, group discussions, as well as StackOverflow
 questions that are relevant to our user community.
+
++++<!-- more -->+++
 
 == Upcoming Events
 

--- a/_posts/2019-06-12-debezium-0-10-0-beta1-released.adoc
+++ b/_posts/2019-06-12-debezium-0-10-0-beta1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Beta1 Released
+date:   2019-06-12 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.10.0.Beta1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 Another week, another Debezium release -- I'm happy to announce the release of Debezium *0.10.0.Beta1*!
 
@@ -22,6 +22,8 @@ Please see the link:/docs/releases/#release-0-10-0-beta1[release notes] for the 
 Also make sure to examine the upgrade guidelines for 0.10.0.Alpha1 and Alpha2 when upgrading from earlier versions.
 
 Many thanks to community members https://github.com/pan3793[Cheng Pan] and https://github.com/ChingTsai[Ching Tsai] for their contributions to this release!
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2019-06-19-debezium-wears-fedora.adoc
+++ b/_posts/2019-06-19-debezium-wears-fedora.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium Wears Fedora
+date:   2019-06-19 10:19:59 -0600
 tags: [ postgres, fedora, vagrant ]
+author: jpechane
 ---
-= Debezium Wears Fedora
-jpechane
-:awestruct-tags: [ postgres, fedora, vagrant ]
-:awestruct-layout: blog-post
 
 The Debezium project strives to provide an easy deployment of connectors,
 so users can try and run connectors of their choice mostly by getting the right connector archive and unpacking it into the plug-in path of Kafka Connect.
@@ -15,6 +15,8 @@ Currently, there are two supported logical plug-ins:
 
 * https://github.com/debezium/[postgres-decoderbufs], which uses Protocol Buffers as a very compact transport format and which is maintained by the Debezium community
 * https://github.com/eulerto/wal2json[JSON-based], which is based on JSON and which is maintained by its own upstream community
+
++++<!-- more -->+++
 
 These plug-ins can be consumed and deployed in two ways;
 the easiest one is to use one of our pre-made https://hub.docker.com/r/debezium/postgres[Postgres container images],

--- a/_posts/2019-06-28-debezium-0-10-0-beta2-released.adoc
+++ b/_posts/2019-06-28-debezium-0-10-0-beta2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Beta2 Released
+date:   2019-06-28 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.10.0.Beta2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *0.10.0.Beta2*!
 
@@ -21,6 +21,8 @@ Also the "include.unknown.datatypes" option works as expected now during snapsho
 (https://issues.redhat.com/browse/DBZ-1335[DBZ-1335])
 and the connector won't stumple upon materialized views during snapshotting any longer
 (https://issues.redhat.com/browse/DBZ-1345[DBZ-1345]).
+
++++<!-- more -->+++
 
 The SQL Server connector will use much less memory in many situations
 (https://issues.redhat.com/browse/DBZ-1065[DBZ-1065])

--- a/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
+++ b/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Tutorial for Adding Sentry into Debezium Container Images
+date:   2019-07-08 10:19:59 -0600
 tags: [ sentry, docker ]
+author: renatomefi
 ---
-= Tutorial for Adding Sentry into Debezium Container Images
-renatomefi
-:awestruct-tags: [ sentry, docker ]
-:awestruct-layout: blog-post
 
 Debezium has received a huge improvement to the structure of its container images link:/blog/2019/06/03/debezium-0-10-0-alpha2-released/[recently],
 making it extremely simple to extend its behaviour.
@@ -19,6 +19,8 @@ We need a few things to have Sentry working, and we'll add all of them and later
 - Configure Log4j
 - SSL certificate for https://sentry.io[sentry.io], since it's not by default in the JVM trusted chain
 - The `sentry` and `sentry-log4j` libraries
+
++++<!-- more -->+++
 
 == Log4j Configuration
 

--- a/_posts/2019-07-12-streaming-cassandra-at-wepay-part-1.adoc
+++ b/_posts/2019-07-12-streaming-cassandra-at-wepay-part-1.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title:  Streaming Cassandra at WePay - Part 1
+date:   2019-07-12 10:19:59 -0600
 tags: [ cassandra ]
 featured: true
+author: joygao
 ---
-= Streaming Cassandra at WePay - Part 1
-joygao
-:awestruct-tags: [ cassandra, featured ]
-:awestruct-layout: blog-post
 
 **_This post originally appeared on the https://wecode.wepay.com/posts/streaming-cassandra-at-wepay-part-1[WePay Engineering blog]._**
 
 Historically, MySQL had been the de-facto database of choice for microservices at WePay. As WePay scales, the sheer volume of data written into some of our microservice databases demanded us to make a scaling decision between sharded MySQL (i.e. link:https://vitess.io[Vitess]) and switching to a natively sharded NoSQL database. After a series of evaluations, we picked Cassandra, a NoSQL database, primarily because of its high availability, horizontal scalability, and ability to handle high write throughput.
+
++++<!-- more -->+++
 
 == Batch ETL Options
 

--- a/_posts/2019-07-15-streaming-cassandra-at-wepay-part-2.adoc
+++ b/_posts/2019-07-15-streaming-cassandra-at-wepay-part-2.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Streaming Cassandra at WePay - Part 2
+date:   2019-07-15 10:19:59 -0600
 tags: [ cassandra ]
+author: joygao
 ---
-= Streaming Cassandra at WePay - Part 2
-joygao
-:awestruct-tags: [ cassandra ]
-:awestruct-layout: blog-post
 
 **_This post originally appeared on the https://wecode.wepay.com/posts/streaming-cassandra-at-wepay-part-2[WePay Engineering blog]._**
 
@@ -13,6 +13,8 @@ In the first half of this blog post series, we explained our decision-making pro
 . Cassandra to Kafka with CDC agent
 . Kafka with BigQuery with KCBQ
 . Transformation with BigQuery view
+
++++<!-- more -->+++
 
 == Cassandra to Kafka with CDC Agent
 

--- a/_posts/2019-07-25-debezium-0-10-0-beta3-released.adoc
+++ b/_posts/2019-07-25-debezium-0-10-0-beta3-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Beta3 Released
+date:   2019-07-25 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: jpechane
 ---
-= Debezium 0.10.0.Beta3 Released
-jpechane
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 The summer is at its peak but Debezium community is not relenting in its effort so the Debezium *0.10.0.Beta3* is released.
 
@@ -12,6 +12,8 @@ This version not only continues in incremental improvements of Debezium but also
 
 All of you who are using PostgreSQL 10 and higher as a service offered by different cloud providers definitely felt the complications when you needed to deploy logical decoding plugin necessary to enable streaming.
 This is no longer necessary. Debezium now supports (https://issues.redhat.com/browse/DBZ-766[DBZ-766]) https://www.postgresql.org/docs/10/protocol-logical-replication.html[pgoutput] replication protocol that is available out-of-the-box since PostgreSQL 10. 
+
++++<!-- more -->+++
 
 There is a set of further minor improvements.
 The tombstones for deletes are configurable for all connectors now (https://issues.redhat.com/browse/DBZ-1365[DBZ-1365]).

--- a/_posts/2019-08-20-debezium-0-10-0-beta4-released.adoc
+++ b/_posts/2019-08-20-debezium-0-10-0-beta4-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.Beta4 Released
+date:   2019-08-20 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
+author: gmorling
 ---
-= Debezium 0.10.0.Beta4 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, docker ]
-:awestruct-layout: blog-post
 
 The temperatures are slowly cooling off after the biggest summer heat,
 an the Debezium community is happy to announce the release of Debezium *0.10.0.Beta4*.
@@ -19,6 +19,8 @@ the Postgres connector now exposes the same metrics you already know from the ot
 
 Finally, the new release contains a range of bugfixes and other useful improvements.
 Let's explore some details below.
+
++++<!-- more -->+++
 
 == Incubating Cassandra Connector
 

--- a/_posts/2019-09-05-website-documentation-overhaul.adoc
+++ b/_posts/2019-09-05-website-documentation-overhaul.adoc
@@ -1,13 +1,15 @@
 ---
+layout: post
+title:  Site and Documentation Overhaul
+date:   2019-09-05 10:19:59 -0600
 tags: [ community, news, website ]
+author: ccranfor
 ---
-= Site and Documentation Overhaul
-ccranfor
-:awestruct-tags: [ community, news, website ]
-:awestruct-layout: blog-post
 
 This past summer has been a super exciting time for the team.
 Not only have we been working hard on Debezium 0.10 but we have unveiled some recent changes to link:/[debezium.io].
+
++++<!-- more -->+++
 
 == New Releases Page
 

--- a/_posts/2019-09-10-debezium-0-10-0-cr1-released.adoc
+++ b/_posts/2019-09-10-debezium-0-10-0-cr1-released.adoc
@@ -1,15 +1,17 @@
 ---
+layout: post
+title:  Debezium 0.10.0.CR1 Released
+date:   2019-09-10 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, cassandra ]
+author: gmorling
 ---
-= Debezium 0.10.0.CR1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, cassandra ]
-:awestruct-layout: blog-post
 
 The Debezium community is on the homestretch towards the 0.10 release and we're happy to announce the availability of Debezium *0.10.0.CR1*!
 
 Besides a number of bugfixes to the different connectors, this release also brings a substantial improvement to the way initial snapshots can be done with Postgres.
 Unless any major regressions show up, the final 0.10 release should follow very soon.
+
++++<!-- more -->+++
 
 == Exported Snapshots for Postgres
 

--- a/_posts/2019-09-26-debezium-0-10-0-cr2-released.adoc
+++ b/_posts/2019-09-26-debezium-0-10-0-cr2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10.0.CR2 Released
+date:   2019-09-26 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, cassandra ]
+author: gmorling
 ---
-= Debezium 0.10.0.CR2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, oracle, cassandra ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *0.10.0.CR2*!
 
@@ -13,6 +13,8 @@ So we adjusted the original plan a bit and now aim for Debezium 0.10 Final in th
 barring any unforeseen regressions.
 
 As usual, let's take a closer look at some of the new features and resolved bugs.
+
++++<!-- more -->+++
 
 == Customizable Message Keys
 

--- a/_posts/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
+++ b/_posts/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
@@ -1,21 +1,20 @@
 ---
-tags: [ discussion, examples, apache-kafka, kafka-streams, featured ]
+layout: post
+title: Building Audit Logs with Change Data Capture and Stream Processing
+author: gmorling
+date:   2019-10-01 10:19:59 -0600
+tags: [ discussion, examples, apache-kafka, kafka-streams ]
 featured: true
 ---
-= Building Audit Logs with Change Data Capture and Stream Processing
-gmorling
-:awestruct-tags: [ discussion, examples, apache-kafka, kafka-streams, featured ]
-:awestruct-layout: blog-post
 
-[role="teaser"]
---
 It is a common requirement for business applications to maintain some form of audit log,
 i.e. a persistent trail of all the changes to the application's data.
 If you squint a bit, a Kafka topic with Debezium data change events is quite similar to that:
 sourced from database transaction logs, it describes all the changes to the records of an application.
 What's missing though is some metadata: why, when and by whom was the data changed?
 In this post we're going to explore how that metadata can be provided and exposed via change data capture (CDC), and how stream processing can be used to enrich the actual data change events with such metadata.
---
+
++++<!-- more -->+++
 
 Reasons for maintaining data audit trails are manyfold:
 e.g. regulatory requirements may mandate businesses to keep complete historic information of their customer, purchase order, invoice or other data.

--- a/_posts/2019-10-02-debezium-0-10-0-final-released.adoc
+++ b/_posts/2019-10-02-debezium-0-10-0-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 0.10 Final Released
+date:   2019-10-02 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra ]
+author: gmorling
 ---
-= Debezium 0.10 Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra ]
-:awestruct-layout: blog-post
 
 On behalf of the Debezium community it's my great pleasure to announce the release of Debezium *0.10.0.Final*!
 

--- a/_posts/2019-10-08-handling-unchanged-postgres-toast-values.adoc
+++ b/_posts/2019-10-08-handling-unchanged-postgres-toast-values.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Strategies for Handling Unchanged Postgres TOAST Values
+date:   2019-10-08 10:19:59 -0600
 tags: [ discussion, examples, postgres, kafka-streams ]
+author: gmorling
 ---
-= Strategies for Handling Unchanged Postgres TOAST Values
-gmorling
-:awestruct-tags: [ discussion, examples, postgres, kafka-streams ]
-:awestruct-layout: blog-post
 
 Let's talk about TOAST.
 Toast?

--- a/_posts/2019-10-17-debezium-1-0-0-beta1-released.adoc
+++ b/_posts/2019-10-17-debezium-1-0-0-beta1-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 1.0.0.Beta1 Released
+date:   2019-10-17 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra ]
+author: ccranfor
 ---
-= Debezium 1.0.0.Beta1 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra ]
-:awestruct-layout: blog-post
 
 History is in the making as Debezium begins to sprint to its 1.0 milestone.
 It's my pleasure to announce the release of Debezium *1.0.0.Beta1*!
@@ -15,6 +15,8 @@ This new Debezium release includes several notable new features, enhancements, a
 * Provides alternative mapping for `INTERVAL` columns via `interval.handling.mode` (https://issues.redhat.com/browse/DBZ-1498[DBZ-1498])
 * Ensure message keys have the right column order (https://issues.redhat.com/browse/DBZ-1507[DBZ-1507])
 * Warn of table locking problems in connector logs (https://issues.redhat.com/browse/DBZ-1280[DBZ-1280])
+
++++<!-- more -->+++
 
 Additionally, several PostgreSQL issues were fixed to improve snapshotting large databases environments (https://issues.redhat.com/browse/DBZ-685[DBZ-685]) and specific circumstances where write ahead logs (WAL) would continue to consume diskspace (https://issues.redhat.com/browse/DBZ-892[DBZ-892]).
 

--- a/_posts/2019-10-17-debezium-newsletter-02-2019.adoc
+++ b/_posts/2019-10-17-debezium-newsletter-02-2019.adoc
@@ -1,13 +1,15 @@
 ---
+layout: post
+title:  Debezium's Newsletter 02/2019
+date:   2019-10-17 10:19:59 -0600
 tags: [ community, news, newsletter ]
+author: ccranfor
 ---
-= Debezium's Newsletter 02/2019
-ccranfor
-:awestruct-tags: [ community, news, newsletter ]
-:awestruct-layout: blog-post
 
 Welcome to the Debezium community newsletter in which we share all things CDC related including blog posts, group discussions, as well as StackOverflow
 questions that are relevant to our user community.
+
++++<!-- more -->+++
 
 == Upcoming Events
 

--- a/_posts/2019-10-22-audit-logs-with-kogito.adoc
+++ b/_posts/2019-10-22-audit-logs-with-kogito.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Admin Service for Audit Logs with Kogito
+date:   2019-10-22 10:19:59 -0600
 tags: [ discussion, examples, apache-kafka, kafka-streams, kogito ]
+author: mswiderski
 ---
-= Admin Service for Audit Logs with Kogito
-mswiderski
-:awestruct-tags: [ discussion, examples, apache-kafka, kafka-streams, kogito ]
-:awestruct-layout: blog-post
 
 As a follow up to the recent link:/blog/2019/10/01/audit-logs-with-change-data-capture-and-stream-processing/[Building Audit Logs with Change Data Capture and Stream Processing] blog post,
 we’d like to extend the example with admin features to make it possible to capture and fix any missing transactional data.
@@ -20,6 +20,7 @@ This all works well as long as all the changes are done via the vegetable servic
 What about maintenance activities or migration scripts executed directly on the database level?
 There are still a lot of such activities going on, either on purpose or because that is our old habits we are trying to change…
 
++++<!-- more -->+++
 
 == Maintenance on database level
 

--- a/_posts/2019-10-24-debezium-1-0-0-beta2-released.adoc
+++ b/_posts/2019-10-24-debezium-1-0-0-beta2-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 1.0.0.Beta2 Released
+date:   2019-10-24 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra ]
+author: ccranfor
 ---
-= Debezium 1.0.0.Beta2 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra ]
-:awestruct-layout: blog-post
 
 It is my pleasure to announce the release of Debezium *1.0.0.Beta2*!
 
@@ -17,6 +17,8 @@ This new Debezium release includes several notable new features, enhancements, a
 * Add MySQL DDL parser support for granting `SESSION_VARIABLES_ADMIN` (https://issues.redhat.com/browse/DBZ-1535[DBZ-1535])
 * Fix MongoDB `collection` source struct field when collection name contains a dot (https://issues.redhat.com/browse/DBZ-1563[DBZ-1563])
 * Close idle transactions after performing a PostgreSQL snapshot (https://issues.redhat.com/browse/DBZ-1564[DBZ-1564])
+
++++<!-- more -->+++
 
 Additionally the PostgreSQL connector was improved to warn users of a common situation where their configuration does not enable heartbeats and the monitored table(s) change less frequent than tables that are not monitored.
 This often lead to the write ahead logs (WAL) consuming additional disk space creating a WAL backlog as the connector only flushes LSN information to PostgreSQL if the log contains events for tables that are monitored.

--- a/_posts/2019-11-14-debezium-1-0-0-beta3-released.adoc
+++ b/_posts/2019-11-14-debezium-1-0-0-beta3-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Debezium 1.0.0.Beta3 Released
+date:   2019-11-14 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra ]
+author: ccranfor
 ---
-= Debezium 1.0.0.Beta3 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra ]
-:awestruct-layout: blog-post
 
 While fall weather is in full swing, the Debezium community is not letting the unusually low, frigid temperatures get the best of us.  It is my pleasure to announce the release of Debezium *1.0.0.Beta3*!
 
@@ -22,6 +22,8 @@ This new Debezium release includes several notable new features, enhancements, a
 * PostgreSQL connector times out in schema discovery for databases with many tables (https://issues.redhat.com/browse/DBZ-1579[DBZ-1579])
 * Value of `ts_ms` is not correct duing snapshot processing (https://issues.redhat.com/browse/DBZ-1588[DBZ-1588])
 * Heartbeats are not generated for non-whitelisted tables (https://issues.redhat.com/browse/DBZ-1592[DBZ-1592])
+
++++<!-- more -->+++
 
 Additionally there were improvements to the Docker container images to reduce their overall size and some build infrastructure improvements to apply automatic code formatting rules.  Details about code formatting changes can be found in the https://github.com/debezium/debezium/blob/master/CONTRIBUTE.md#code-formatting[CONTRIBUTE.md] file.
 

--- a/_posts/2019-12-12-debezium-1-0-0-cr1-released.adoc
+++ b/_posts/2019-12-12-debezium-1-0-0-cr1-released.adoc
@@ -1,10 +1,10 @@
 ---
-tags:  [ releases, mysql, postgres, sqlserver ]
+layout: post
+title:  Debezium 1.0.0.CR1 Released
+date:   2019-12-12 10:19:59 -0600
+tags: [ releases, mysql, postgres, sqlserver ]
+author: gmorling
 ---
-= Debezium 1.0.0.CR1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver ]
-:awestruct-layout: blog-post
 
 Did you know December 12th is National Ding-a-Ling Day?
 It's the day to call old friends you haven't heard from in a while.
@@ -17,6 +17,8 @@ Quite a few nice features found their way into CR1:
 * Advanced type support for Postgres: the long awaited enum types (https://issues.redhat.com/browse/DBZ-920[DBZ-920]), domain types (https://issues.redhat.com/browse/DBZ-1413[DBZ-1413]) and arrays of UUIDs (https://issues.redhat.com/browse/DBZ-1637[DBZ-1637])
 * Graceful handling of MongoDB 4.0 transaction events (https://issues.redhat.com/browse/DBZ-1215[DBZ-1215])
 * Full support for Java 11, including the upgrade to Java 11 in the Debezium container images for Apache Kafka and Connect (https://issues.redhat.com/browse/DBZ-969[DBZ-969], https://issues.redhat.com/browse/DBZ-1402[DBZ-1402])
+
++++<!-- more -->+++
 
 There was a number of bug fixes, too:
 

--- a/_posts/2019-12-13-externalized-secrets.adoc
+++ b/_posts/2019-12-13-externalized-secrets.adoc
@@ -1,14 +1,16 @@
 ---
+layout: post
+title:  Secrets externalization with Debezium connectors
+date:   2019-12-13 10:19:59 -0600
 tags: [ secrets, mysql, example ]
+author: jpechane
 ---
-= Secrets externalization with Debezium connectors
-jpechane
-:awestruct-tags: [ secrets, mysql, example ]
-:awestruct-layout: blog-post
 
 When a Debezium connector is deployed to a Kafka Connect instance it is sometimes necessary to keep database credentials hidden from other users of the Connect API.
 
 Let's remind how a connector registration request looks like for the MySQL Debezium connector:
+
++++<!-- more -->+++
 
 [source,json]
 ----

--- a/_posts/2019-12-18-debezium-1-0-0-final-released.adoc
+++ b/_posts/2019-12-18-debezium-1-0-0-final-released.adoc
@@ -1,10 +1,10 @@
 ---
+layout: post
+title:  Streaming Now- Debezium 1.0 Final Is Out
+date:   2019-12-18 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, mongodb, cassandra, oracle ]
+author: gmorling
 ---
-= "Streaming Now: Debezium 1.0 Final Is Out"
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, mongodb, cassandra, oracle ]
-:awestruct-layout: blog-post
 
 Today it's my great pleasure to announce the availability of Debezium *1.0.0.Final*!
 
@@ -18,6 +18,8 @@ some with huge installations, using hundreds of connectors to stream data change
 
 The 1.0 release marks an important milestone for the project:
 based on all the production feedback we got from the users of the 0.x versions, we figured it's about time to express the maturity of the four stable connectors in the version number, too.
+
++++<!-- more -->+++
 
 == Why Debezium?
 

--- a/_posts/2020-01-16-debezium-1-1-alpha1-released.adoc
+++ b/_posts/2020-01-16-debezium-1-1-alpha1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-01-16 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver ]
 author: gmorling
 ---
-= Debezium 1.1.0.Alpha1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver ]
-:awestruct-layout: blog-post
 
 Did you know January 16th is https://en.wikipedia.org/wiki/National_Nothing_Day[National Nothing Day]?
 It's the one day in the year without celebrating, observing or honoring anything.
@@ -18,6 +14,8 @@ Because we couldn't stop ourselves from sharing the news of the Debezium *1.1.0.
 It's the first release after Debezium 1.0,
 and there are some really useful features coming with it.
 Let's take a closer look.
+
++++<!-- more -->+++
 
 == Quarkus Outbox Pattern Extension
 

--- a/_posts/2020-01-22-outbox-quarkus-extension.adoc
+++ b/_posts/2020-01-22-outbox-quarkus-extension.adoc
@@ -5,10 +5,6 @@ date:   2020-01-22 10:19:59 -0600
 tags: [ discussion, examples, outbox, quarkus ]
 author: ccranfor
 ---
-= Outbox Event Router goes Supersonic!
-ccranfor
-:awestruct-tags: [ discussion, examples, outbox, quarkus ]
-:awestruct-layout: blog-post
 
 Outbox as in that folder in my email client?
 No, not exactly but there are some similarities!
@@ -21,6 +17,8 @@ So what exactly is an Outbox Event Router?
 
 In Debezium version 0.9.3.Final, we introduced a ready-to-use https://kafka.apache.org/documentation/#connect_transforms[Single Message Transform] (SMT) that builds on the Outbox pattern to propagate data change events using Debezium and Kafka.
 Please see the link:https://debezium.io/documentation/reference/1.1/configuration/outbox-event-router.html[documentation] for details on how to use this transformation.
+
++++<!-- more -->+++
 
 == Going Supersonic with Quarkus!
 

--- a/_posts/2020-02-10-event-sourcing-vs-cdc.adoc
+++ b/_posts/2020-02-10-event-sourcing-vs-cdc.adoc
@@ -3,13 +3,9 @@ layout: post
 title:  Distributed Data for Microservices — Event Sourcing vs. Change Data Capture
 date:   2020-02-10 10:19:59 -0600
 featured: true
-tags: [ discussion, event-sourcing, cqrs, outbox, quarkus, featured ]
+tags: [ discussion, event-sourcing, cqrs, outbox, quarkus ]
 author: murphye
 ---
-= Distributed Data for Microservices — Event Sourcing vs. Change Data Capture
-murphye
-:awestruct-tags: [ discussion, event-sourcing, cqrs, outbox, quarkus, featured ]
-:awestruct-layout: blog-post
 
 This article is a dive into the realms of Event Sourcing, Command Query Responsibility Segregation (CQRS), Change Data Capture (CDC), and the Outbox Pattern. Much needed clarity on the value of these solutions will be presented. Additionally, two differing designs will be explained in detail with the pros/cons of each.
 
@@ -18,6 +14,8 @@ So why do all these solutions even matter? They matter because many teams are bu
 Solutions that help avoid these serious problems are of paramount importance for many organizations. Unfortunately, many vital solutions are somewhat difficult to understand; Event Sourcing, CQRS, CDC, and Outbox are no exception. Please look at these solutions as an opportunity to learn and understand how they could apply to your specific use cases.
 
 As you will find out at the end of this article, I will propose that three of these four solutions have high value, while the other should be discouraged except for the rarest of circumstances. The advice given in this article should be evaluated against your specific needs, because, in some cases, none of these four solutions would be a good fit.
+
++++<!-- more -->+++
 
 == Reactive Systems
 

--- a/_posts/2020-02-11-debezium-1-1-beta1-released.adoc
+++ b/_posts/2020-02-11-debezium-1-1-beta1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-02-11 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, cassandra, db2 ]
 author: gmorling
 ---
-= Debezium 1.1.0.Beta1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, cassandra, db2 ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *1.1.0.Beta1*!
 
@@ -19,6 +15,8 @@ we've backported an asorted set of bug fixes to the 1.0 branch and released Debe
 
 At the time of writing this, not all connector archives have been synched to Maven Central yet;
 this should be the case within the next few others.
+
++++<!-- more -->+++
 
 == Transaction Markers
 

--- a/_posts/2020-02-13-debezium-1-1-beta2-released.adoc
+++ b/_posts/2020-02-13-debezium-1-1-beta2-released.adoc
@@ -5,10 +5,6 @@ date:   2020-02-13 10:19:59 -0600
 tags: [ releases, postgres, mongodb, oracle, sqlserver, db2, outbox, quarkus ]
 author: gmorling
 ---
-= Debezium 1.1.0.Beta2 Released
-gmorling
-:awestruct-tags: [ releases, postgres, mongodb, oracle, sqlserver, db2, outbox, quarkus ]
-:awestruct-layout: blog-post
 
 Release early, release often!
 After the 1.1 Beta1 and 1.0.1 Final releases earlier this week, I'm today happy to share the news about the release of Debezium *1.1.0.Beta2*!
@@ -16,6 +12,8 @@ After the 1.1 Beta1 and 1.0.1 Final releases earlier this week, I'm today happy 
 The main addition in Beta2 is support for integration tests of your change data capture (CDC) set-up using Testcontainers.
 In addition, the Quarkus extension for implementing the outbox pattern as well as
 the SMT for extracting the `after` state of change events have been re-worked and offer more configuration flexibility now.
+
++++<!-- more -->+++
 
 == Testcontainers Support
 

--- a/_posts/2020-02-19-debezium-camel-integration.adoc
+++ b/_posts/2020-02-19-debezium-camel-integration.adoc
@@ -5,10 +5,6 @@ date:   2020-02-19 10:19:59 -0600
 tags: [ camel, integration, quarkus ]
 author: jpechane
 ---
-= Integration Scenarios with Debezium and Apache Camel
-jpechane
-:awestruct-tags: [ camel, integration, quarkus ]
-:awestruct-layout: blog-post
 
 One of the typical Debezium uses cases is to use change data capture to integrate a legacy system with other systems in the organization.
 There are multiple ways how to achieve this goal
@@ -18,6 +14,8 @@ There are multiple ways how to achieve this goal
 * Use an existing integration framework or service bus to express the pipeline logic
 
 This article is focusing on the third option - a dedicated integration framework.
+
++++<!-- more -->+++
 
 == Apache Camel
 

--- a/_posts/2020-02-25-lessons-learned-running-debezium-with-postgresql-on-rds.adoc
+++ b/_posts/2020-02-25-lessons-learned-running-debezium-with-postgresql-on-rds.adoc
@@ -5,12 +5,10 @@ date:   2020-02-25 10:19:59 -0600
 tags: [ aws, postgres, rds ]
 author: hashhar
 ---
-= Lessons Learned from Running Debezium with PostgreSQL on Amazon RDS
-hashhar
-:awestruct-tags: [ aws, postgres, rds ]
-:awestruct-layout: blog-post
 
 In this blog post, we are going to discuss how https://www.delhivery.com/[Delhivery], the leading supply chain services company in India, is using Debezium to power a lot of different business use-cases ranging from driving event driven microservices, providing data integration and moving operational data to a data warehouse for real-time analytics and reporting. We will also take a look at the early mistakes we made when integrating Debezium and how we solved them so that any future users can avoid them, discuss one of the more challenging production incidents we faced and how Debezium helped ensure we could recover without any data loss. In closing, we discuss what value Debezium has provided us, areas where we believe there is a scope for improvement and how Debezium fits into our future goals.
+
++++<!-- more -->+++
 
 == Debezium at Delhivery
 

--- a/_posts/2020-03-05-db2-cdc-approaches.adoc
+++ b/_posts/2020-03-05-db2-cdc-approaches.adoc
@@ -5,11 +5,6 @@ date:   2020-03-05 10:19:59 -0600
 tags: [ db2, discussion ]
 author: lga-zurich,SeanRooooney,zrlurb
 ---
-= Approaches to Running Change Data Capture for Db2 
-
-lga-zurich,SeanRooooney,zrlurb
-:awestruct-tags: [ db2, discussion ]
-:awestruct-layout: blog-post
 
 We have developed a Debezium connector for usage with link:https://www.ibm.com/analytics/db2[Db2] which
 is now available as part of the Debezium incubator.
@@ -17,6 +12,8 @@ Here we describe the use case we have for Change Data Capture (CDC),
 the various approaches that already exist in the Db2 ecology,
 and how we came to Debezium. In addition, we motivate the approach
 we took to implementing the Db2 Debezium connector.
+
++++<!-- more -->+++
 
 == Background: Bringing Data to a Datalake
 

--- a/_posts/2020-03-13-debezium-1-1-c1-released.adoc
+++ b/_posts/2020-03-13-debezium-1-1-c1-released.adoc
@@ -5,15 +5,13 @@ date:   2020-03-13 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, oracle, sqlserver, db2 ]
 author: gmorling
 ---
-= Debezium 1.1.0.CR1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, oracle, sqlserver, db2 ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *1.1.0.CR1*!
 
 This release brings a brand-new API module, including a facility for overriding the schema and value conversion of specific columns.
 The Postgres connector gained the ability to reconnect to the database after a connection loss, and the MongoDB connector supports the metrics known from other connectors now.
+
++++<!-- more -->+++
 
 == The Debezium API Module
 

--- a/_posts/2020-03-19-integration-testing-for-change-data-capture-with-testcontainers.adoc
+++ b/_posts/2020-03-19-integration-testing-for-change-data-capture-with-testcontainers.adoc
@@ -5,10 +5,6 @@ date:   2020-03-19 10:19:59 -0600
 tags: [ discussion, testcontainers, postgres ]
 author: gmorling
 ---
-= Integration Testing for Change Data Capture with Testcontainers
-gmorling
-:awestruct-tags: [ discussion, testcontainers, postgres ]
-:awestruct-layout: blog-post
 
 Setting up change data capture (CDC) pipelines with Debezium typically is a matter of configuration,
 without any programming being involved.

--- a/_posts/2020-03-24-debezium-1-1-final-released.adoc
+++ b/_posts/2020-03-24-debezium-1-1-final-released.adoc
@@ -5,10 +5,6 @@ date:   2020-03-24 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, oracle, sqlserver, db2, cassandra ]
 author: gmorling
 ---
-= Debezium 1.1.0.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, oracle, sqlserver, db2, cassandra ]
-:awestruct-layout: blog-post
 
 It's with great excitement that I'm announcing the release of Debezium *1.1.0.Final*!
 
@@ -20,6 +16,8 @@ About three months after the 1.0 release, this new version comes with many excit
 * transaction marker events
 * support for link:/documentation/reference/1.1/integrations/testcontainers.html[CDC integration testing] via Testcontainers
 * a brand-new API Debezium module containing a reworked link:/documentation/reference/1.1/development/engine.html[embedded engine API] as well as an SPI for link:/documentation/reference/1.1/development/converters.html[customizing schema and values of change events]
+
++++<!-- more -->+++
 
 Besides these key features, there's many other smaller improvements such as reconnects for the Postgres connector, more flexibility when extracting the `after` state from change events,
 and more powerful options for propagating metadata on the source types of captured columns.

--- a/_posts/2020-03-31-debezium-newsletter-01-2020.adoc
+++ b/_posts/2020-03-31-debezium-newsletter-01-2020.adoc
@@ -5,15 +5,13 @@ date:   2020-03-31 10:19:59 -0600
 tags: [ community, news, newsletter ]
 author: ccranfor
 ---
-= Debezium's Newsletter 01/2020
-ccranfor
-:awestruct-tags: [ community, news, newsletter ]
-:awestruct-layout: blog-post
 
 Welcome to the latest edition of the Debezium community newsletter, in which we share all things CDC related including blog posts, group discussions, as well as StackOverflow
 questions that are relevant to our user community.
 
 In case you missed our last edition, you can check it out link:/blog/2019/10/17/debezium-newsletter-02-2019/[here].
+
++++<!-- more -->+++
 
 == Upcoming Events
 

--- a/_posts/2020-04-09-using-debezium-wit-apicurio-api-schema-registry.adoc
+++ b/_posts/2020-04-09-using-debezium-wit-apicurio-api-schema-registry.adoc
@@ -1,0 +1,648 @@
+---
+layout: post
+title:  Using Debezium With the Apicurio API and Schema Registry
+date:   2020-04-09 10:19:59 -0600
+tags: [ schema, avro, apicurio ]
+author: jpechane
+---
+
+Change events streamed from a database by Debezium are (in developer parlance) strongly typed.
+This means that event consumers should be aware of the types of data conveyed in the events.
+This problem of passing along message type data can be solved in multiple ways:
+
++++<!-- more -->+++
+
+. the message structure is passed out-of-band to the consumer, which is able to process the data stored in it
+. the message contains metadata (the _schema_) that is embedded within the message
+. the message contains a reference to a registry which contains the associated metadata
+
+An example of the first case is Apache Kafka's well known `JsonConverter`.
+It can operate in two modes - with and without schemas.
+When configured to work without schemas, it generates a plain JSON message where the consumer either needs to know the types of each field beforehand, or it needs to execute heuristic rules to "guess" and map values to datatypes.
+While this approach is quite flexible it can fail for more advanced cases, e.g. temporal or other semantic types encoded as strings.
+Also, constraints associated with the types are usually lost.
+
+Here's an example of such a message:
+
+[source,json]
+----
+{
+  "before": null,
+  "after": {
+    "id": 1001,
+    "first_name": "Sally",
+    "last_name": "Thomas",
+    "email": "sally.thomas@acme.com"
+  },
+  "source": {
+    "version": "1.1.0.Final",
+    "connector": "mysql",
+    "name": "dbserver1",
+    "ts_ms": 0,
+    "snapshot": "true",
+    "db": "inventory",
+    "table": "customers",
+    "server_id": 0,
+    "gtid": null,
+    "file": "mysql-bin.000003",
+    "pos": 154,
+    "row": 0,
+    "thread": null,
+    "query": null
+  },
+  "op": "c",
+  "ts_ms": 1586331101491,
+  "transaction": null
+}
+----
+
+Note how no type information beyond JSON's basic type system is present.
+E.g. a consumer cannot conclude from the event itself, which length the numeric `id` field has.
+
+An example of the second case is again `JsonConverter`.
+By means of its `schemas.enable` option, the JSON message will consist of two parts - `schema` and `payload`.
+The `payload` part is exactly the same as in the previous case; the `schema` part contains a description of the message, its fields, field types and associated type constraints.
+This enables the consumer to process the message in a type-safe way.
+The drawback of this approach is that the message size has increased significantly, as the schema is quite a large object.
+As schemas tend to be changed rarely (how often do you change the definitions of the columns of your database tables?),
+adding the schema to each and every event poses a signficant overhead.
+
+The following example of a message with a schema clearly shows that the schema itself can be significantly larger than the payload and is not very economical to use:
+
+[source,json]
+----
+{
+  "schema": {
+    "type": "struct",
+    "fields": [
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "first_name"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "last_name"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "email"
+          }
+        ],
+        "optional": true,
+        "name": "dbserver1.inventory.customers.Value",
+        "field": "before"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "int32",
+            "optional": false,
+            "field": "id"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "first_name"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "last_name"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "email"
+          }
+        ],
+        "optional": true,
+        "name": "dbserver1.inventory.customers.Value",
+        "field": "after"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "version"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "connector"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "name"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "ts_ms"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "name": "io.debezium.data.Enum",
+            "version": 1,
+            "parameters": {
+              "allowed": "true,last,false"
+            },
+            "default": "false",
+            "field": "snapshot"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "db"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "table"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "server_id"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "gtid"
+          },
+          {
+            "type": "string",
+            "optional": false,
+            "field": "file"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "pos"
+          },
+          {
+            "type": "int32",
+            "optional": false,
+            "field": "row"
+          },
+          {
+            "type": "int64",
+            "optional": true,
+            "field": "thread"
+          },
+          {
+            "type": "string",
+            "optional": true,
+            "field": "query"
+          }
+        ],
+        "optional": false,
+        "name": "io.debezium.connector.mysql.Source",
+        "field": "source"
+      },
+      {
+        "type": "string",
+        "optional": false,
+        "field": "op"
+      },
+      {
+        "type": "int64",
+        "optional": true,
+        "field": "ts_ms"
+      },
+      {
+        "type": "struct",
+        "fields": [
+          {
+            "type": "string",
+            "optional": false,
+            "field": "id"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "total_order"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "data_collection_order"
+          }
+        ],
+        "optional": true,
+        "field": "transaction"
+      }
+    ],
+    "optional": false,
+    "name": "dbserver1.inventory.customers.Envelope"
+  },
+  "payload": {
+    "before": null,
+    "after": {
+      "id": 1001,
+      "first_name": "Sally",
+      "last_name": "Thomas",
+      "email": "sally.thomas@acme.com"
+    },
+    "source": {
+      "version": "1.1.0.Final",
+      "connector": "mysql",
+      "name": "dbserver1",
+      "ts_ms": 0,
+      "snapshot": "true",
+      "db": "inventory",
+      "table": "customers",
+      "server_id": 0,
+      "gtid": null,
+      "file": "mysql-bin.000003",
+      "pos": 154,
+      "row": 0,
+      "thread": null,
+      "query": null
+    },
+    "op": "c",
+    "ts_ms": 1586331101491,
+    "transaction": null
+  }
+}
+----
+
+== Registry
+
+Then there is the third approach that combines strong points of the first two, while it removes their drawbacks at the cost of introducing a new component - a registry - that stores and versions message schemas.
+
+There are multiple schema registry implementations available;
+in the following we're going to focus on the https://github.com/Apicurio/apicurio-registry[Apicurio Registry],
+which is an open-source (Apache license 2.0) API and schema registry.
+The project provides not only the registry itself, but also client libraries and tight integration with Apache Kafka and Kafka Connect in form of serializers and converters.
+
+Apicurio enables Debezium and consumers to exchange messages whose schema is stored in the registry and pass only a reference to the schema in the messages themselves.
+A the structure of captured source tables and thus message schemas evolve, the registry creates new versions of the schemas, too, so not only current but also historical schemas are available.
+
+Apicurio provides multiple serialization formats out-of-the-box:
+
+* JSON with externalized schema support
+* https://avro.apache.org/[Apache Avro]
+* https://developers.google.com/protocol-buffers[Protocol Buffers]
+
+Every serializer and deserializer knows how to automatically interact with the Apicurio API so the consumer is isolated from it as an implementation detail.
+The only information necessary is the location of the registry.
+
+Apicurio also provides API compatibility layers for schema registries from IBM and Confluent.
+This is a very useful feature, as it enables the use of 3rd-party tools like https://github.com/edenhill/kafkacat[kafkacat], even if they are not aware of Apicurio's native API.
+
+=== JSON Converter
+
+In the Debezium examples repository, there is a https://github.com/debezium/debezium-examples/blob/master/tutorial/docker-compose-mysql-apicurio.yaml[Docker Compose] based example, that deploys the Apicurio registry side-by-side with the standard Debezium tutorial example setup.
+
+[.centered-image.responsive-image]
+====
+++++
+<img src="/assets/images/2020-04-09-debezium-apicurio-registry/topology.png" style="max-width:100%;" class="responsive-image">
+++++
+*Figure 1. The Deployment Topology*
+====
+
+To follow the example you need to clone the Debezium https://github.com/debezium/debezium-examples/[example repository].
+
+[NOTE]
+====
+Since Debezium 1.2 the https://hub.docker.com/r/debezium/connect/[Debezium container images] are shipped
+with Apicurio converter support.
+
+You can enable Apicurio converters by using a `debezium/connect` or `debezium/connect-base` image version >=1.2 and
+adding the environment variable `ENABLE_APICURIO_CONVERTERS=true`.
+====
+
+[source,bash]
+----
+$ cd tutorial
+$ export DEBZIUM_VERSION=1.1
+
+# Start the deployment
+$ docker-compose -f docker-compose-mysql-apicurio.yaml up -d --build
+
+# Start the connector
+curl -i -X POST -H "Accept:application/json" \
+    -H  "Content-Type:application/json" \
+    http://localhost:8083/connectors/ -d @register-mysql-apicurio-converter-json.json
+
+# Read content of the first message
+$ docker run --rm --tty \
+    --network tutorial_default debezium/tooling bash \
+    -c 'kafkacat -b kafka:9092 -C -o beginning -q -t dbserver1.inventory.customers -c 1 | jq .'
+----
+
+The resulting message should look like:
+
+[source,json]
+----
+{
+  "schemaId": 48,
+  "payload": {
+    "before": null,
+    "after": {
+      "id": 1001,
+      "first_name": "Sally",
+      "last_name": "Thomas",
+      "email": "sally.thomas@acme.com"
+    },
+    "source": {
+      "version": "1.1.0.Final",
+      "connector": "mysql",
+      "name": "dbserver1",
+      "ts_ms": 0,
+      "snapshot": "true",
+      "db": "inventory",
+      "table": "customers",
+      "server_id": 0,
+      "gtid": null,
+      "file": "mysql-bin.000003",
+      "pos": 154,
+      "row": 0,
+      "thread": null,
+      "query": null
+    },
+    "op": "c",
+    "ts_ms": 1586334283147,
+    "transaction": null
+  }
+}
+----
+
+The JSON message contains the full payload and at the same time a reference to a schema with id `48`.
+It is possible to query the schema from the registry either using `id` or using a schema symbolic name as defined by Debezium documentation.
+In this case both commands
+
+[source,bash]
+----
+$ docker run --rm --tty \
+    --network tutorial_default \
+    debezium/tooling bash -c 'http http://apicurio:8080/ids/64 | jq .'
+
+$ docker run --rm --tty \
+    --network tutorial_default \
+    debezium/tooling bash -c 'http http://apicurio:8080/artifacts/dbserver1.inventory.customers-value | jq .'
+----
+
+result in the same schema description:
+
+[source,json]
+----
+{
+  "type": "struct",
+  "fields": [
+    {
+      "type": "struct",
+      "fields": [
+        {
+          "type": "int32",
+          "optional": false,
+          "field": "id"
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "field": "first_name"
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "field": "last_name"
+        },
+        {
+          "type": "string",
+          "optional": false,
+          "field": "email"
+        }
+      ],
+      "optional": true,
+      "name": "dbserver1.inventory.customers.Value",
+      "field": "before"
+    },
+...
+  ],
+  "optional": false,
+  "name": "dbserver1.inventory.customers.Envelope"
+}
+----
+
+Which is the same as we have seen in the "JSON with schema" example before.
+
+The connector registration request differs in a few lines from the previous one:
+
+[source,json]
+----
+...
+"key.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter", <1>
+"key.converter.apicurio.registry.url": "http://apicurio:8080", <2>
+"key.converter.apicurio.registry.global-id":
+    "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy", <3>
+
+"value.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter", <1>
+"value.converter.apicurio.registry.url": "http://apicurio:8080", <2>
+"value.converter.apicurio.registry.global-id":
+    "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy" <3>
+...
+----
+<1> The Apicurio JSON converter is used as both key and value converter
+<2> The Apicurio registry endpoint
+<3> This setting ensures that it is posible to automatically register the schema id which is the typical setting in Debezium deployment
+
+=== Avro Converter
+
+So far we have demonstrated serialization of messages into the JSON format only.
+While using the JSON format with the registry has a lot of advantages, like easy human readability, it's still not very space-efficient.
+
+To transfer really only the data without any significant overhead, it is useful to use binary format serialization like Avro format.
+In this case, we would pack the data only without any field names and other ceremony, and again the message will contain a reference to a schema stored in the registry.
+
+Let's look at how easily the Avro serialization can be used with Apicurio's Avro converter.
+
+[source,bash]
+----
+# Tear down the previous deployment
+$ docker-compose -f docker-compose-mysql-apicurio.yaml down
+
+# Start the deployment
+$ docker-compose -f docker-compose-mysql-apicurio.yaml up -d --build
+
+# Start the connector
+curl -i -X POST -H "Accept:application/json" \
+    -H  "Content-Type:application/json" \
+    http://localhost:8083/connectors/ \
+    -d @register-mysql-apicurio-converter-avro.json
+----
+
+We can query the registry using schema name:
+
+[source,bash]
+----
+$ docker run --rm --tty \
+    --network tutorial_default \
+    debezium/tooling \
+    bash -c 'http http://apicurio:8080/artifacts/dbserver1.inventory.customers-value | jq .'
+----
+
+The resulting schema description is slightly different for the previous ones as it has an Avro flavour:
+
+[source,json]
+----
+{
+  "type": "record",
+  "name": "Envelope",
+  "namespace": "dbserver1.inventory.customers",
+  "fields": [
+    {
+      "name": "before",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "Value",
+          "fields": [
+            {
+              "name": "id",
+              "type": "int"
+            },
+            {
+              "name": "first_name",
+              "type": "string"
+            },
+            {
+              "name": "last_name",
+              "type": "string"
+            },
+            {
+              "name": "email",
+              "type": "string"
+            }
+          ],
+          "connect.name": "dbserver1.inventory.customers.Value"
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "after",
+      "type": [
+        "null",
+        "Value"
+      ],
+      "default": null
+    },
+...
+  ],
+  "connect.name": "dbserver1.inventory.customers.Envelope"
+}
+----
+
+The connector registration request also differs from the standard one in a handful of lines:
+
+[source,json]
+----
+...
+"key.converter": "io.apicurio.registry.utils.converter.AvroConverter", <1>
+"key.converter.apicurio.registry.url": "http://apicurio:8080", <2>
+"key.converter.apicurio.registry.converter.serializer":
+    "io.apicurio.registry.utils.serde.AvroKafkaSerializer", <3>
+"key.converter.apicurio.registry.converter.deserializer":
+    "io.apicurio.registry.utils.serde.AvroKafkaDeserializer", <3>
+"key.converter.apicurio.registry.global-id":
+    "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy", <4>
+
+"value.converter": "io.apicurio.registry.utils.converter.AvroConverter", <1>
+"value.converter.apicurio.registry.url": "http://apicurio:8080", <2>
+"value.converter.apicurio.registry.converter.serializer":
+    "io.apicurio.registry.utils.serde.AvroKafkaSerializer", <3>
+"value.converter.apicurio.registry.converter.deserializer":
+    "io.apicurio.registry.utils.serde.AvroKafkaDeserializer", <3>
+"value.converter.apicurio.registry.global-id":
+    "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy", <4>
+...
+----
+<1> The Apicurio Avro converter is used as both key and value converter
+<2> The Apicurio registry endpoint
+<3> Prescribes which serializer and deserializer should be used by the converter
+<4> This setting ensures that it is posible to automatically register the schema id which is the typical setting in Debezium deployment
+
+To demonstrate consumption of the messages on the sink side we can, for example, use the https://github.com/confluentinc/kafka-connect-elasticsearch[Kafka Connect Elasticsearch connector]. The sink configuration will be again extended only with converter configuration, and the sink connector can consume Avro-enabled topics, without any other changes needed.
+
+[source,json]
+----
+{
+  "name": "elastic-sink",
+  "config": {
+    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+    "tasks.max": "1",
+    "topics": "customers",
+    "connection.url": "http://elastic:9200",
+    "transforms": "unwrap,key",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState",
+    "transforms.unwrap.drop.tombstones": "false",
+    "transforms.key.type": "org.apache.kafka.connect.transforms.ExtractField$Key",
+    "transforms.key.field": "id",
+    "key.ignore": "false",
+    "type.name": "customer",
+    "behavior.on.null.values": "delete",
+
+    "key.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+    "key.converter.apicurio.registry.url": "http://apicurio:8080",
+    "key.converter.apicurio.registry.converter.serializer":
+        "io.apicurio.registry.utils.serde.AvroKafkaSerializer",
+    "key.converter.apicurio.registry.converter.deserializer":
+        "io.apicurio.registry.utils.serde.AvroKafkaDeserializer",
+    "key.converter.apicurio.registry.global-id":
+        "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
+
+    "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+    "value.converter.apicurio.registry.url": "http://apicurio:8080",
+    "value.converter.apicurio.registry.converter.serializer":
+        "io.apicurio.registry.utils.serde.AvroKafkaSerializer",
+    "value.converter.apicurio.registry.converter.deserializer":
+        "io.apicurio.registry.utils.serde.AvroKafkaDeserializer",
+    "value.converter.apicurio.registry.global-id":
+        "io.apicurio.registry.utils.serde.strategy.GetOrCreateIdStrategy",
+  }
+}
+----
+
+== Conclusion
+
+In this article we discussed multiple approaches to message/schema association.
+The Apicurio registry was presented as a solution for schema sotrage and versioning and we have demonstrated how Apicurio can be integrated with Debezium connectors to efficiently deliver messages with schema to the consumer.
+
+You can find a complete example for using the Debezium connectors together with the Apicurio registry in the https://github.com/debezium/debezium-examples/tree/master/tutorial#using-mysql-and-apicurio-registry[tutorial] project of the Debezium examples repository on GitHub.
+
+== About Debezium
+
+Debezium is an open-source distributed platform that turns your existing databases into event streams,
+so applications can see and respond almost instantly to each committed row-level change in the databases.
+Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
+Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
+ensuring that all events are processed correctly and completely.
+Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
+
+== Get involved
+
+We hope you find Debezium interesting and useful and want to give it a try.
+Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
+or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
+All of the code is open-source https://github.com/debezium/[on GitHub],
+so build the code locally and help us improve our existing connectors and add even more connectors.
+If you find problems or have an idea on how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-04-16-debezium-1-2-alpha1-released.adoc
+++ b/_posts/2020-04-16-debezium-1-2-alpha1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-04-16 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra ]
 author: gmorling
 ---
-= Debezium 1.2.0.Alpha1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *1.2.0.Alpha1*!
 
@@ -21,6 +17,8 @@ This first drop of the 1.2 release line provides a number of useful new features
 
 Overall, the community fixed not less than https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.2.0.Alpha1%20ORDER%20BY%20issuetype%20DESC[41 issues] for this release.
 Let's take a closer look at some of them in the remainder of this post.
+
++++<!-- more -->+++
 
 == Embedded Engine Improvements
 

--- a/_posts/2020-05-07-debezium-1-2-beta1-released.adoc
+++ b/_posts/2020-05-07-debezium-1-2-beta1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-05-07 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, oracle, db2 ]
 author: gmorling
 ---
-= Debezium 1.2.0.Beta1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, oracle, db2 ]
-:awestruct-layout: blog-post
 
 With great happiness I'm announcing the release of Debezium *1.2.0.Beta1*!
 
@@ -18,6 +14,8 @@ support for a range of array column types in Postgres and much more.
 We also upgraded the Debezium container images for Apache Kafka and Kafka Connect to version 2.5.0.
 
 As it's the answer to all questions in life, the number of issues fixed for this release is https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.2.0.Beta1%20ORDER%20BY%20issuetype%20DESC[exactly 42]!
+
++++<!-- more -->+++
 
 == Schema Change Topics
 

--- a/_posts/2020-05-19-debezium-1-2-beta2-released.adoc
+++ b/_posts/2020-05-19-debezium-1-2-beta2-released.adoc
@@ -5,10 +5,6 @@ date:   2020-05-19 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, testcontainers, debezium-server ]
 author: gmorling
 ---
-= Debezium 1.2.0.Beta2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, testcontainers, debezium-server ]
-:awestruct-layout: blog-post
 
 I'm very happy to share the news that Debezium *1.2.0.Beta2* has been released!
 
@@ -17,6 +13,8 @@ a dedicated stand-alone runtime for Debezium, opening up its open-source change 
 
 Overall, the community has fixed https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.2.0.Beta2%20ORDER%20BY%20issuetype%20DESC[25 issues] since the Beta1 release,
 some of which we're going to explore in more depth in the remainder of this post.
+
++++<!-- more -->+++
 
 == Debezium Server
 

--- a/_posts/2020-06-11-debezium-1-2-cr1-released.adoc
+++ b/_posts/2020-06-11-debezium-1-2-cr1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-06-11 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, testcontainers, ebezium-server ]
 author: ccranfor
 ---
-= Debezium 1.2.0.CR1 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, testcontainers, debezium-server ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *1.2.0.CR1*!
 
@@ -40,6 +36,8 @@ https://github.com/jfinzel[Jeremy Finzel],
 https://github.com/keweishang[Kewei Shang],
 https://github.com/metlos[Lukas Krejci], and
 https://github.com/RobertHana[Robert B. Hanviriyapunt].
+
++++<!-- more -->+++
 
 == About Debezium
 

--- a/_posts/2020-06-24-debezium-1-2-final-released.adoc
+++ b/_posts/2020-06-24-debezium-1-2-final-released.adoc
@@ -5,10 +5,6 @@ date:   2020-06-24 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, oracle, debezium-server ]
 author: gmorling
 ---
-= Debezium 1.2.0.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, oracle, debezium-server ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *1.2.0.Final*!
 
@@ -22,6 +18,8 @@ Upgrade to Apache Kafka 2.5
 * A new column masking mode "consistent hashing", allowing to anonymize column values while still keeping them correlatable
 * New metrics for the MongoDB connector
 * Improved re-connect capability for the SQL Server connector
+
++++<!-- more -->+++
 
 == Debezium Server
 

--- a/_posts/2020-07-16-debezium-1-2-1-final-released.adoc
+++ b/_posts/2020-07-16-debezium-1-2-1-final-released.adoc
@@ -5,10 +5,6 @@ date:   2020-07-16 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, testcontainers, debezium-server ]
 author: gmorling
 ---
-= Debezium 1.2.1.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, testcontainers, debezium-server ]
-:awestruct-layout: blog-post
 
 I am happy to announce the release of Debezium *1.2.1.Final*!
 
@@ -23,6 +19,8 @@ which fixes a CVE in the driver related to processing XML column values sourced 
 it also handles single dimension `DECIMAL` columns in `CAST` expressions (https://issues.redhat.com/browse/DBZ-2305[DBZ-2305])
 * The MySQL connector automatically filters out specific DML binlog entries from internal tables when using it with Amazon RDS (https://issues.redhat.com/browse/DBZ-2275[DBZ-2275])
 * The Debezium MongoDB connector got more resilient against connection losses (https://issues.redhat.com/browse/DBZ-2141[DBZ-2141])
+
++++<!-- more -->+++
 
 If you're using the https://www.apicur.io/registry/[Apicurio] open-source API and schema registry for link:/documentation/reference/configuration/avro.html[managing the JSON and Avro schemas] of your Debezium connectors,
 then things got a bit simpler for you:

--- a/_posts/2020-07-28-hello-debezium.adoc
+++ b/_posts/2020-07-28-hello-debezium.adoc
@@ -5,10 +5,6 @@ date:   2020-07-28 10:19:59 -0600
 tags: [ community, news ]
 author: rkerner
 ---
-= Hello Debezium Team!
-rkerner
-:awestruct-tags: [ community, news ]
-:awestruct-layout: blog-post
 
 Hello everyone, my name is René Kerner and I recently joined Red Hat and the Debezium team.
 

--- a/_posts/2020-08-06-debezium-1-3-alpha1-released.adoc
+++ b/_posts/2020-08-06-debezium-1-3-alpha1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-08-06 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2 ]
 author: ccranfor
 ---
-= Debezium 1.3.0.Alpha1 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2 ]
-:awestruct-layout: blog-post
 
 I'm excited to announce the release of Debezium *1.3.0.Alpha1*!
 
@@ -20,6 +16,8 @@ This initial pass in the 1.3 release line provides a number of useful new featur
 
 Overall, the community fixed not less than https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.3.0.Alpha1%20ORDER%20BY%20issuetype%20DESC[31 issues] for this release.
 Let's take a closer look at some of them in the remainder of this post.
+
++++<!-- more -->+++
 
 == Azure Event Hubs sink adapter
 

--- a/_posts/2020-09-03-debezium-1-3-beta1-released.adoc
+++ b/_posts/2020-09-03-debezium-1-3-beta1-released.adoc
@@ -5,15 +5,13 @@ date:  2020-09-03 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
 author: gmorling
 ---
-= Debezium 1.3.0.Beta1 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
-:awestruct-layout: blog-post
 
 It's my pleasure to announce the release of Debezium *1.3.0.Beta1*!
 
 This release upgrades to the recently released Apache Kafka version 2.6.0, fixes several critical bugs and comes with a renaming of the connector configuration options for selecting the tables to be captured.
 We've also released Debezium 1.2.2.Final, which is a drop-in replacement for all users of earlier 1.2.x releases.
+
++++<!-- more -->+++
 
 == Revised Filter Options and Documentation Wording
 

--- a/_posts/2020-09-15-debezium-auto-create-topics.adoc
+++ b/_posts/2020-09-15-debezium-auto-create-topics.adoc
@@ -5,10 +5,6 @@ date:   2020-09-15 10:19:59 -0600
 tags: [ kafka, topics, production, news, discussion ]
 author: rkerner
 ---
-= Auto-creating Debezium Change Data Topics
-rkerner
-:awestruct-tags: [ kafka, topics, production, news, discussion ]
-:awestruct-layout: blog-post
 
 ++++
 <div class="imageblock centered-image">

--- a/_posts/2020-09-16-debezium-1-3-beta2-released.adoc
+++ b/_posts/2020-09-16-debezium-1-3-beta2-released.adoc
@@ -5,10 +5,6 @@ date:   2020-09-16 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
 author: gmorling
 ---
-= Debezium 1.3.0.Beta2 Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *1.3.0.Beta2*!
 
@@ -17,6 +13,8 @@ and there's a brand-new implementation for ingesting change events from Oracle, 
 As we're on the home stretch towards Debezium 1.3 Final,
 there's also a wide range of smaller improvements, bug fixes and documentation clarifications;
 overall, not less than https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.3.0.Beta2%20ORDER%20BY%20issuetype%20DESC&startIndex=20[44 issues] have been resolved for this release.
+
++++<!-- more -->+++
 
 == Column Filtering Improvements
 

--- a/_posts/2020-09-24-debezium-1-3-cr1-released.adoc
+++ b/_posts/2020-09-24-debezium-1-3-cr1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-09-24 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
 author: ccranfor
 ---
-= Debezium 1.3.0.CR1 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, outbox ]
-:awestruct-layout: blog-post
 
 I'm very happy to announce the release of Debezium *1.3.0.CR1*!
 
@@ -16,6 +12,8 @@ As we approach the final stretch of Debezium 1.3 Final,
 we took this opportunity to add delegate converter support for the `ByteBufferConverter` and introduce a `debezium-scripting` module.
 In addition, there's also a range of bug fixes and quite a bit of documentation polish;
 overall, not less than https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.3.0.CR1%20ORDER%20BY%20issuetype%20DESC&startIndex=20[15 issues] have been resolved for this release.
+
++++<!-- more -->+++
 
 == ByteBufferConverter improvements
 

--- a/_posts/2020-10-01-debezium-1-3-final-released.adoc
+++ b/_posts/2020-10-01-debezium-1-3-final-released.adoc
@@ -5,10 +5,6 @@ date:   2020-10-01 10:19:59 -0600
 tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, db2, vitess, outbox ]
 author: gmorling
 ---
-= Debezium 1.3.0.Final Released
-gmorling
-:awestruct-tags: [ releases, mysql, postgres, sqlserver, cassandra, oracle, db2, vitess, outbox ]
-:awestruct-layout: blog-post
 
 It's with great please that I'm announcing the release of Debezium *1.3.0.Final*!
 
@@ -23,6 +19,8 @@ Overall, the community has fixed https://issues.redhat.com/issues/?jql=project%2
 * Support for database-filtered columns for SQL Server
 * Additional connection options for the MongoDB connector
 * Improvements to `ByteBufferConverter` for implementing the link:/documentation/reference/configuration/outbox-event-router.html[outbox pattern] with Avro as the payload format
+
++++<!-- more -->+++
 
 Please refer to the announcements of the preview releases (https://debezium.io/blog/2020/08/06/debezium-1-3-alpha1-released/[Alpha1], https://debezium.io/blog/2020/09/03/debezium-1-3-beta1-released/[Beta1], https://debezium.io/blog/2020/09/16/debezium-1-3-beta2-released/[Beta2], https://debezium.io/blog/2020/09/24/debezium-1-3-cr1-released/[CR1]) for more details.
 Since last week's CR1 release, we've https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.3.0.Final%20ORDER%20BY%20issuetype%20DESC%2C%20updated%20DESC%2C%20priority%20DESC[been focusing] on ironing out some remaining bugs and improvements to the documentation.

--- a/_posts/2020-10-08-debezium-community-stories-with-renato-mefi.adoc
+++ b/_posts/2020-10-08-debezium-community-stories-with-renato-mefi.adoc
@@ -5,16 +5,10 @@ date:   2020-10-08 10:19:59 -0600
 tags: [ community, outbox ]
 author: gmorling
 ---
-= Debezium Community Stories With... Renato Mefi
-gmorling
-:awestruct-tags: [ community, outbox ]
-:awestruct-layout: blog-post
 
-[role="teaser"]
---
 Welcome to the first edition of "Debezium Community Stories With...", a new series of interviews with members of the Debezium and change data capture community, such as users, contributors or integrators. We're planning to publish more parts of this series in a loose rhythm, so if you'd like to be part of it, please let us know.
 In today's edition it's my pleasure to talk to https://twitter.com/renatomefi[Renato Mefi], a long-time Debezium user and contributor.
---
++++<!-- more -->+++
 
 [.centered-image.responsive-image]
 ====

--- a/_posts/2020-10-22-towards-debezium-ui.adoc
+++ b/_posts/2020-10-22-towards-debezium-ui.adoc
@@ -5,10 +5,6 @@ date:   2020-10-22 10:19:59 -0600
 tags: [ community, discussion ]
 author: gmorling
 ---
-= Towards a Graphical Debezium User Interface
-gmorling
-:awestruct-tags: [ community, discussion ]
-:awestruct-layout: blog-post
 
 Over the last five years, Debezium has become a leading open-source solution for change data capture for a variety of databases.
 Users from all kinds of industries work with Debezium for use cases like replication of data from operational databases into data warehouses, updating caches and search indexes, driving streaming queries via Kafka Streams or Apache Flink, synchronizing data between microservices, and many more.
@@ -18,6 +14,7 @@ allowing to safely operate CDC pipelines also in huge installations with thousan
 
 All this comes at the cost of a learning curve, though: users new to Debezium need to understand the different options and settings as well as learn about best practices for running Debezium in production.
 We're therefore constantly exploring how the user experience of Debezium can be further improved, allowing people to set up and operate its connectors more easily.
++++<!-- more -->+++
 
 Today it's my great pleasure to introduce you to a proof-of-concept for a potential future *Debezium graphical user interface*.
 The goal for this PoC is to explore how a graphical UI could facilitate the getting started and operational experience of Debezium users.

--- a/_posts/2020-10-23-debezium-1-4-alpha1-released.adoc
+++ b/_posts/2020-10-23-debezium-1-4-alpha1-released.adoc
@@ -5,10 +5,6 @@ date:   2020-10-23 10:19:59 -0600
 tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, oracle, vitess ]
 author: ccranfor
 ---
-= Debezium 1.4.0.Alpha1 Released
-ccranfor
-:awestruct-tags: [ releases, mysql, postgres, mongodb, sqlserver, cassandra, db2, oracle, vitess ]
-:awestruct-layout: blog-post
 
 I am excited to announce the release of Debezium *1.4.0.Alpha1*!
 
@@ -19,6 +15,7 @@ This first pass of the 1.4 release line provides a few useful new features:
 
 Overall, the community fixed https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fixVersion%20%3D%201.4.0.Alpha1%20ORDER%20BY%20issuetype%20DESC[41 issues] for this release.
 Let's take a closer look at some of the highlights.
++++<!-- more -->+++
 
 == Vitess Connector
 

--- a/_posts/2020-10-27-hello-debezium.adoc
+++ b/_posts/2020-10-27-hello-debezium.adoc
@@ -5,10 +5,6 @@ date:   2020-10-23 10:19:59 -0600
 tags: [ community, news ]
 author: anmohant
 ---
-= Hello Debezium!
-anmohant
-:awestruct-tags: [ community, news ]
-:awestruct-layout: blog-post
 
 Hello everyone, my name is Anisha Mohanty and I recently joined Red Hat and the Debezium team.
 

--- a/_posts/2020-11-04-streaming-vitess-at-bolt.adoc
+++ b/_posts/2020-11-04-streaming-vitess-at-bolt.adoc
@@ -3,16 +3,16 @@ layout: post
 title:  Streaming Vitess at Bolt
 date:   2020-11-04 10:19:59 -0600
 featured: true
-tags: [ vitess, featured ]
+tags: [ vitess ]
 author: keweishang, rgibaiev
 ---
-= Streaming Vitess at Bolt
 
 **_This post originally appeared on the https://medium.com/bolt-labs/streaming-vitess-at-bolt-f8ea93211c3f[Bolt Labs Engineering blog]._**
 
 Traditionally, MySQL has been used to power most of the backend services at link:https://bolt.eu/en/[Bolt]. We've designed our schemas in a way that they're sharded into different MySQL clusters. Each MySQL cluster contains a subset of data and consists of one primary and multiple replication nodes.
 
 Once data is persisted to the database, we use the link:https://debezium.io/documentation/reference/connectors/mysql.html[Debezium MySQL Connector] to link:https://www.confluent.io/blog/how-bolt-adopted-cdc-with-confluent-for-real-time-data-and-analytics/[capture data change events] and send them to Kafka. This gives us an easy and reliable way to communicate changes between back-end microservices.
++++<!-- more -->+++
 
 == Vitess at Bolt
 


### PR DESCRIPTION
- Fixes to preserve formatting in blog post excerpts - defined 'excerpt_separator' in _config.yml and utilized in the blog posts.  If a blog post does not contain the separator, the excerpt is generated without html tags.
- Fix broken blog post links to other blog posts, by fixing blog post url template to agree with original site
- added one missing blog post
- removed awestruct info from blog posts and made front matters consistent in all of the posts