### PR TITLE
Update readme for website-migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contribute to Debezium's website
 
-Our website is a community effort, and we welcome suggestions, fixes, improvements, and even new blog posts related to Debezium. The website is statically generated from [source code](https://github.com/debezium/debezium.io) using [Awestruct](http://awestruct.org) and [Bootstrap](http://twitter.github.com/bootstrap). This document outlines the basic steps require to get the latest source code for the website, modify it, test it locally, and create pull requests. And, yes, this process is intentionally very similar to how we [contribute code](https://github.com/debezium/debezium/blob/develop/CONTRIBUTE.md).
+Our website is a community effort, and we welcome suggestions, fixes, improvements, and even new blog posts related to Debezium. The website is statically generated from [source code](https://github.com/debezium/debezium.io) using [Jekyll](https://jekyllrb.com) and [Bootstrap](http://twitter.github.com/bootstrap). This document outlines the basic steps require to get the latest source code for the website, modify it, test it locally, and create pull requests. And, yes, this process is intentionally very similar to how we [contribute code](https://github.com/debezium/debezium/blob/develop/CONTRIBUTE.md).
 
 ### Talk to us
 
@@ -72,29 +72,29 @@ To build the source code locally, checkout and update the `develop` branch:
     $ git checkout develop
     $ git pull upstream develop
 
-Then use Docker to run a container that initializes the Awestruct tooling. Start a new terminal, configure it with the Docker environment (if required), and run the following command:
+Then use Docker to run a container that initializes the Jekyll tooling. Start a new terminal, configure it with the Docker environment (if required), and run the following command:
 
-    $ docker run -it --rm -p 4242:4242 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site debezium/awestruct setup
+    $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site uidoyen/newjekyll setup
     
 *Note:* Some times you may wish to use the `root` user of your linux machine to run docker (as docker needs elevated privileges to run). It's probably a better idea to run docker containers while [running as a user other than root and using sudo](http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/) or adding the [user to the group that has privileges](https://developer.fedoraproject.org/tools/docker/docker-installation.html) to run docker. When you checkout the code for this project don't clone the source code and try running this command as the `root` user. When you do this, all of the code (and the entire folder) then gets owned by the `root` user. The reason why this is undesirable is when we run `docker run -v $(pwd):/site` we are actually mounting the local file system where the source code lives _into_ the docker container. If this directory is owned by `root`, the image cannot create the necessary directories for running `rake` and `bundle`.     
 
 This should download all of the Ruby Gems the tooling uses, as defined in the `Gemfile` file. After it completes, run a container using the same image but with a different command:
 
-    $ docker run -it --rm -p 4242:4242 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site debezium/awestruct bash
+    $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site uidoyen/newjekyll bash
 
-This command will start a container using the `debezium/awestruct` Docker image, first downloading the image if necessary. It also mounts the current directory (where the website code is located) into the container's `/site` directory. 
+This command will start a container using the `debezium/jekyll` Docker image, first downloading the image if necessary. It also mounts the current directory (where the website code is located) into the container's `/site` directory. 
 
 Next, at the command line of that container run the following command:
 
     /site$ rake clean preview
 
-This cleans up any previously-generated files in the `_site` directory, (re)generates the files for the website, and runs a local webserver to access the site by pointing your browser to [http://localhost:4242]().
+This cleans up any previously-generated files in the `_site` directory, (re)generates the files for the website, and runs a local webserver to access the site by pointing your browser to [http://localhost:4000]().
 
 Note: With documentation maintained in the main Debezium code repository you may want to edit documentation locally and review how it renders prior to committing changes.  In order to use author mode, two things must be done:
 
 1. The docker container must have an additional volume mapped that points to the main Debezium repository that you've checked out locally.  In this example, we've checked out the https://github.com/debezium/debezium repository to `~/github/debezium`.  So in order to map that directory as a volume on the docker container, you will additionally need to provide the argument `-v ~/github/debezium:/debezium` when starting the container.  Below is an example of how it should look:
 
-        $ docker run -it --rm -p 4242:4242 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site -v ~/github/debezium:/debezium debezium/awestruct bash
+        $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site -v ~/github/debezium:/debezium uidoyen/newjekyll bash
         
       When inside the docker container, you should notice a `/debezium` directory now exists and its contents is that of the checked out repository.  In the event you do not see a `/debezium` directory or that its contents are empty or incorrect, please review how you mapped the volume above.
       
@@ -108,14 +108,14 @@ Note: With documentation maintained in the main Debezium code repository you may
         
       If it reports that its using `playbook.yml` instead, then author mode was not properly requested and you should check how you invoked rake.                     
 
-Note: If you're running Docker on Windows or OS X, you must use [port forwarding](https://debezium.io/docs/docker#port-forwarding) so that requests get forwarded properly to the Docker host virtual machine. For example, to port forward when using a Vagrant based VM (virtualbox, etc), you can port forward the `4242` port easily like this:
+Note: If you're running Docker on Windows or OS X, you must use [port forwarding](https://debezium.io/docs/docker#port-forwarding) so that requests get forwarded properly to the Docker host virtual machine. For example, to port forward when using a Vagrant based VM (virtualbox, etc), you can port forward the `4000` port easily like this:
 
 
-    vagrant ssh -- -vnNTL *:4242:$DOCKER_HOST_IP:4242    
+    vagrant ssh -- -vnNTL *:4000:$DOCKER_HOST_IP:4000    
 
 #### Changing the source
 
-You can edit and change the source files at any time. For small modifications, Awestruct will often recognize the changes and then regenerate the affected static pages. However, this recognition may not work for additions, deletions, or even larger modifications. In this case, use CTRL-C to stop the Awestruct webserver in the Docker container, and rerun the same command:
+You can edit and change the source files at any time. For small modifications, Jekyll will often recognize the changes and then regenerate the affected static pages. However, this recognition may not work for additions, deletions, or even larger modifications. In this case, use CTRL-C to stop the Jekyll webserver in the Docker container, and rerun the same command:
 
     /site$ rake clean preview
 
@@ -190,9 +190,7 @@ and in your fork:
 
 ### Site characteristics
 
-When you build the site, the Awestruct tools will generate all of the static files for the site and place them into a local `_site` directory. These are the only files that will appear on the public website.
-
-We want the site to have nice URLs, so Awestruct has an _indexer_ that will transform each file into a folder with the same root name as the file and placing the content into an `index.hmtl` inside that folder. For example, the content from the `/community.html.haml` source file is placed into the `_site/community/index.html` file, which can be viewed on the website with the URL `https://debezium.io/community`.
+When you build the site, the Jekyll tools will generate all of the static files for the site and place them into a local `_site` directory. These are the only files that will appear on the public website.
 
 ### Common changes
 
@@ -200,14 +198,17 @@ Some changes to the website are fairly common, so they're described here.
 
 #### Add a blog post
 
-Anyone can write a blog post that is related to Debezium. Simply add a new AsciiDoc file to the `blog` directory, including the date in the filename using the same format as the other files (e.g., "2016-03-18-title-of-blog-post.adoc"). The file should also contain a header like the following:
+Anyone can write a blog post that is related to Debezium. Simply add a new AsciiDoc file to the `blog` directory, including the date in the filename using the same format as the other files (e.g., "2016-03-18-title-of-blog-post.adoc"). The file should also contain jekyll front matter like the following:
 
-    = Title Of Blog Post
-    rhauch
-    :awestruct-tags: [ mysql, sql ]
-    :awestruct-layout: blog-post
+    ---
+    layout: post
+    title:  Title of Blog Post
+    date:   yyyy-mm-dd
+    tags: [ tag1, tag2 ]
+    author: theAuthor
+    ---
 
-The second line is the key to an entry in the `_config/authors.yml` file, so the first time be sure to add an entry for yourself (avatar images go in the `images` directory). Specify the appropriate lowercase tags, surrounding multi-word tags with double quotes. The `:awestruct-layout` line should remain the same.
+The author is the key to an entry in the `_data/authors.yaml` file, so the first time be sure to add an entry for yourself (avatar images go in the `assets/images` directory). Specify the appropriate lowercase tags, surrounding multi-word tags with double quotes.
 
 Then, rebuild the site and make sure your post is formatted correctly and appears in the [blog](https://debezium.io/blog/).
 
@@ -295,7 +296,7 @@ For connector entries, specify the `database -> versions` and `driver -> version
 _Note that since a series.yml file describes a release series and not a specific bugfix release, the contents of the file should reflect what the latest test compatibility is for the most recent release within the series._
 _So as new releases are added to a given series, its important to update the series.yml file with the pertinent connector and driver tested versions_.
 
-The _hidden_ attribute describes whether or not the series should be exposed on the website at all.   In general, when a series is considered legacy/old and no longer relevant, this attribute can be set to _true_ and no reference to this version will be included in the awestruct output.
+The _hidden_ attribute describes whether or not the series should be exposed on the website at all.   In general, when a series is considered legacy/old and no longer relevant, this attribute can be set to _true_ and no reference to this version will be included in the jekyll output.
 
 The _displayed_ attribute describes whether or not the series is considered _active_.  On the Releases Overview, we render boxes for all displayed (e.g. active) series.  There is a subsection that is hidden initially for older releases.  If _hidden=false_ and _displayed=false_, then that series will show up under the "Show Older Series" button.
 
@@ -349,7 +350,7 @@ Note: There are two Antora playbook configuration files used by this repository,
 
 #### Update the front page
 
-The site's main page is located in the `/index.html.haml` file.
+The site's main page is defined in `/index.md`, which utilizes `_layouts/index.html` layout.
 
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,42 @@
-# Upstream Community Theme
+[![Build Status](https://travis-ci.org/debezium/debezium.github.io.svg?branch=develop)](https://travis-ci.org/debezium/debezium.github.io)
+[![License](http://img.shields.io/:license-CC%20BY%203.0-brightgreen.svg)](http://creativecommons.org/licenses/by/3.0/)
+[![Developer chat](https://img.shields.io/badge/chat-devs-brightgreen.svg)](https://gitter.im/debezium/dev)
+[![Google Group](https://img.shields.io/:mailing%20list-debezium-brightgreen.svg)](https://groups.google.com/forum/#!forum/debezium)
 
-The Upstream Community Theme is a ready-to-use [Jekyll](https://jekyllrb.com/) theme to help you create a basic static site for your project. It was designed with the Red Hat Upstream Community in mind, but can be used by anyone looking to create a simple, lightweight site.
+# Introduction
 
-## Getting Started
+This is the source code for the [Debezium website](https://debezium.io/). This is based on [templates](https://github.com/rhmwes/community-theme) created by the Red Hat Upstream Community using [Jekyll](https://jekyllrb.com/).
 
-These instructions will get you a copy of the project up and running on your local machine for development purposes. See deployment for notes on how to deploy the project on [GitHub Pages](https://pages.github.com/).
+For publishing the Debezium reference documentation, the [Antora](https://antora.org/) tool is used,
+which produces the documentation based on [AsciiDoc files](https://github.com/debezium/debezium/tree/master/documentation) in different branches of the Debezium main code repository.
+The rendered HTML pages are added as-is to the website generated with Jekyll.
+Please see [ANTORA.md](./ANTORA.md) to learn more.
 
-### Prerequisites
+# License
 
- - Install a full [Ruby development environment](https://www.ruby-lang.org/en/downloads/). Ruby version 2.4.0 or above is required, including all development headers. You can run `ruby -v` to check your current Ruby version.
- - [RubyGems](https://rubygems.org/pages/download). You can run `gem -v` to check if you have RubyGems installed.
- - [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). You can run `gcc -v`,`g++ -v` and `make -v` to see if your system already has them installed.
+Contents of this repository are available as open source software under [Apache License Version 2.0](./LICENSE.txt).
 
-### Installing the theme
+# System Requirements
 
-*[Jekyll documentation pages](https://jekyllrb.com/docs/)*
+We use [Docker](http://docker.com) to build the site. Be sure you have a recent version of the [Docker Engine](http://docs.docker.com/engine/installation/) or [Docker Machine](http://docs.docker.com/toolbox).
 
-1. The Jekyll site provides detailed installation instructions for each operating system:
- 
-  - [Mac](https://jekyllrb.com/docs/installation/macos/)
-  - [Linux distributions including Red Hat Linux](https://jekyllrb.com/docs/installation/other-linux)
-  - [Ubuntu Linux](https://jekyllrb.com/docs/installation/ubuntu/)
-  - [Windows](https://jekyllrb.com/docs/installation/windows/)
-    
-3. Fork this repository by clicking the _Fork_ button at the top right corner of this page.
-4. Clone your fork (please ensure you have current version of git installed) by running: 
-  `git clone git@github.com:YOUR_USER_NAME/community-theme.git`
-5. Change into the project directory
-  `cd community-theme`
-6. Build the site and make it available on a local server
-  `rake clean preview`
-7. To preview your site, browse to http://localhost:4000
+# Getting Started
 
-> If you encounter any unexpected errors during the above, please refer to the [troubleshooting](https://jekyllrb.com/docs/troubleshooting/#configuration-problems) page or the [requirements](https://jekyllrb.com/docs/installation/#requirements) page, as you might be missing development headers or other prerequisites.
+### 1. Get the site source code
 
-_For more information regarding the use of Jekyll, please refer to the [Jekyll Step by Step Tutorial](https://jekyllrb.com/docs/step-by-step/01-setup/)._
+Use Git to clone the Debezium website Git repository and change into that directory:
 
-### 1. Start the development webserver
+    $ git clone https://github.com/debezium/debezium.github.io.git
+    $ cd debezium.github.io
+
+If you plan to submit changes, fork the [Git repository](http://github.com/debezium/debezium.github.io) on GitHub and then add your fork as a remote:
+
+    $ git remote rename origin upstream
+    $ git remote add origin https://github.com/<you>/debezium.github.io.git
+
+Then check out the `develop` branch and get the latest. If you're going to make changes, create a topic branch and make the changes there.
+
+### 2. Start the development webserver
 
 In a new terminal initialized with the Docker host environment, start a Docker container that has the build environment for our website:
 
@@ -55,36 +55,20 @@ This should only need to be performed once. After the libraries are installed, w
     
 With the integration with Antora, the above command will now also fetch the main codebase repository and will invoke the Antora build process to build the version-specific documentation prior to invoking Awestruct.  For information on Antora and how we've integrated it into the build process, please see ANTORA.md.
 
-### 2. View the site
+### 3. View the site
 
 Point your browser to [http://localhost:4000](http://localhost:4000) to view the site. You may notice some delay during development, since the site is generated somewhat lazily.
 
-## Deployment on GitHub Pages
+### 4. Edit the site
 
-To deploy your site using GitHub Pages you will need to add the [github-pages gem](https://github.com/github/pages-gem).
+Use any development tools on your local machine to edit the source files for the site. For very minor modifications, Jekyll will detect the changes and may regenerate the corresponding static file(s). However, we generally recommend that you use CNTRL-C in the container shell to stop the preview server, re-run the `rake clean preview` command, and refresh your browser.
 
-> Note that GitHub Pages runs in `safe` mode and only allows a set of [whitelisted plugins](https://help.github.com/articles/configuring-jekyll-plugins/#default-plugins).
+If you have to change the Gemfile to use different libraries, you will need to let the container download the new versions. The simplest way to do this is to stop the container (using CTRL-C), use `rm -rf bundler` to remove the directory where the gem files are stored, and then restart the container. This ensures that you're always using the exact files that are specified in the Gemfile.lock file.
 
-To use the github-pages gem, you'll need to add the following on your `Gemfile`:
+### 5. Commit changes
 
-```
-source "https://rubygems.org"
-gem "github-pages", group: :jekyll_plugins
-```
-And then run `bundle update`.
+Use Git on your local machine to commit the changes to the site's codebase to your topic branch, and then create a pull request.
 
-To deploy a project page that is kept in the same repository as the project they are for, please refer to the *Project Pages* section in [Deploying Jekyll to GitHub Pages](https://jekyllrb.com/docs/github-pages/#deploying-jekyll-to-github-pages).
+### 6. Publish the website
 
-
-## Contributing
-
-Please read [CONTRIBUTING.md](https://gist.github.com/PurpleBooth/b24679402957c63ec426) for details on the process for submitting pull requests to us.
-
-## Authors
-
-* [**Adela Sofia A.**](https://github.com/adelasofia) - *Initial theme implementation*
-* [**Jason Brock**](https://github.com/jkbrock) - *Visual Designer*
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details.
+Review the pull request and merge onto the `develop` branch. The [Travis-CI build](https://travis-ci.org/debezium/debezium.github.io) will then build the `develop` branch and, if successful, store the generated site in the `master` branch and publish to the GitHub Pages.


### PR DESCRIPTION
updating the readme for the website-migration branch.  Essentially it is now the same as the develop branch with appropriate edits for the jekyll setup.  Will need further updates as additional changes are made to the process