### PR TITLE
moves repeated blog section into template

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -122,6 +122,33 @@ layout: base
       
     
     {% endif %}
+    <div class="row">
+      <div class="col-md-12">
+        <hr>
+        <h2>About Debezium</h2>
+        <p>
+          Debezium is an open source distributed platform that turns your existing databases into event streams,
+          so applications can see and respond almost instantly to each committed row-level change in the databases.
+          Debezium is built on top of <a href="http://kafka.apache.org/">Kafka</a> and provides <a href="http://kafka.apache.org/documentation.html#connect">Kafka Connect</a> compatible connectors that monitor specific database management systems.
+          Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
+          ensuring that all events are processed correctly and completely.
+          Debezium is <a href="/license/">open source</a> under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License, Version 2.0</a>.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <h2>Get involved</h2>
+        <p>
+          We hope you find Debezium interesting and useful, and want to give it a try.
+          Follow us on Twitter <a href="https://twitter.com/debezium">@debezium</a>, <a href="https://gitter.im/debezium/user">chat with us on Gitter</a>,
+          or join our <a href="https://groups.google.com/forum/#!forum/debezium">mailing list</a> to talk with the community.
+          All of the code is open source <a href="https://github.com/debezium/">on GitHub</a>,
+          so build the code locally and help us improve ours existing connectors and add even more connectors.
+          If you find problems or have ideas how we can improve Debezium, please let us know or <a href="https://issues.redhat.com/projects/DBZ/issues/">log an issue</a>.
+        </p>
+      </div>
+    </div>
     {% if site.disqus.shortname %}
     {% include disqus_comments.html %}
     {% endif %}

--- a/_posts/2016-06-10-Debezium-0.2.1-Released.adoc
+++ b/_posts/2016-06-10-Debezium-0.2.1-Released.adoc
@@ -30,13 +30,3 @@ To use the connector to produce change events for a particular MySQL server or c
 Although Debezium is really intended to be used as turnkey services, all of Debezium's JARs and other artifacts are available in http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.debezium%22[Maven Central]. You might want to use our link:/blog/2016/04/15/parsing-ddl/[MySQL DDL parser] from our MySQL connector library to parse those DDL statments in your consumers. 
 
 We do provide a small library so applications can link:/docs/embedded/[embed any Kafka Connect connector] and consume data change events read directly from the source system. This provides a much lighter weight system (since Zookeeper, Kafka, and Kafka Connect services are not needed), but as a consequence is not as fault tolerant or reliable since the application must manage and maintain all state normally kept inside Kafka's distributed and replicated logs. It's perfect for use in tests, and with careful consideration it may be useful in some applications.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue]. And stay tuned, because we're hoping to add a MongoDB connector in our next release.
-
-Thanks to Emmanuel, Chris, Christian, Konstantin, David, Akshath, James, Ewen, Cheng, and Paul for their help with the release, discussions, design assistance, contributions, and questions!

--- a/_posts/2016-06-22-Debezium-0-2-2-Released.adoc
+++ b/_posts/2016-06-22-Debezium-0-2-2-Released.adoc
@@ -14,12 +14,4 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 
 +++<!-- more -->+++
 
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue]. And stay tuned, because we're hoping to add a MongoDB connector in our next release.
-
 Thanks to Chris, Christian, Konstantin, James, and Bhupinder for their help with the release, issues, discussions, contributions, and questions!

--- a/_posts/2016-07-26-Debezium-0-2-3-Released.adoc
+++ b/_posts/2016-07-26-Debezium-0-2-3-Released.adoc
@@ -14,11 +14,3 @@ Thanks to Chris, Christian, Laogang, and Tony for their help with the release, i
 Stay tuned for our next release, which will be 0.3 and will have a new MongoDB connector and will support Kafka Connect 0.10.0.0.
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-08-16-Debezium-0-2-4-Released.adoc
+++ b/_posts/2016-08-16-Debezium-0-2-4-Released.adoc
@@ -14,11 +14,3 @@ Thanks to David and wangshao for their help with the release, issues, discussion
 Stay tuned for our next release, which will be 0.3 and will have a new MongoDB connector and will support Kafka Connect 0.10.0.1.
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-08-16-Debezium-0-3-0-Released.adoc
+++ b/_posts/2016-08-16-Debezium-0-3-0-Released.adoc
@@ -13,11 +13,3 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 Thanks to Andrew, Bhupinder, Chris, David, Horia, Konstantin, Tony, and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-08-30-Debezium-0-3-1-Released.adoc
+++ b/_posts/2016-08-30-Debezium-0-3-1-Released.adoc
@@ -13,11 +13,3 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 Thanks to Chris, Akshath, barten, and and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-09-26-Debezium-0-3-2-Released.adoc
+++ b/_posts/2016-09-26-Debezium-0-3-2-Released.adoc
@@ -13,11 +13,3 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 Thanks to Akshath, Colum, Emmanuel, Konstantin, Randy, RenZhu, Umang, and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-10-18-Debezium-0-3-3-Released.adoc
+++ b/_posts/2016-10-18-Debezium-0-3-3-Released.adoc
@@ -13,11 +13,3 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 Thanks to Akshath, Chris, Randy, Prannoy, Umang, Horia, and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-10-25-Debezium-0-3-4-Released.adoc
+++ b/_posts/2016-10-25-Debezium-0-3-4-Released.adoc
@@ -13,11 +13,3 @@ We've also updated the https://hub.docker.com/r/debezium/[Debezium Docker images
 Thanks to Akshath, Chris, Vitalii, Dennis, Prannoy, and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-11-14-Debezium-0-3-5-Released.adoc
+++ b/_posts/2016-11-14-Debezium-0-3-5-Released.adoc
@@ -14,11 +14,3 @@ One of the fixes is signficant, and so *we strongly urge all users to upgrade to
 Thanks to Akshath, Anton, Chris, and others for their help with the release, issues, discussions, contributions, and questions!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2016-12-21-Debezium-0-3-6-Released.adoc
+++ b/_posts/2016-12-21-Debezium-0-3-6-Released.adoc
@@ -17,11 +17,3 @@ Thanks to Farid, RenZhu, Dongjun, Anton, Chris, Dennis, Sharaf, Rodrigo, Tim, an
 == What's next
 
 We'll continue to improve the MongoDB and MySQL connectors, and we also have a great PostgreSQL connector that is nearly ready to be released. With the new connector we'll switch release numbers to 0.4.x and plan to stop issuing 0.3.x releases. Stay tuned for this next 0.4.0 release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve the MySQL connector and add more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-02-07-Debezium-0-4-0-Released.adoc
+++ b/_posts/2017-02-07-Debezium-0-4-0-Released.adoc
@@ -17,11 +17,3 @@ Thanks to Horia, Chris, Akshath, Ramesh, Matthias, Anton, Sagi, barton, and othe
 == What's next
 
 We'll continue to improve the MongoDB, MySQL, and PostgreSQL connectors and pushing out 0.4.x releases. We're also going to work on a few new connectors, though we'll likely increase the minor version with each new connector. Stay tuned and get involved!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve ours existing connectors and add even more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-03-17-Debezium-0-4-1-Released.adoc
+++ b/_posts/2017-03-17-Debezium-0-4-1-Released.adoc
@@ -17,11 +17,3 @@ Thanks to Jan, Horia, David, Josh, Johan, Sanjay, Saulius, and everyone in the c
 == What's next
 
 Kafka 0.10.2.0 is out, so we plan to release 0.5.0 next week with all of the changes/fixes in 0.4.1 but with support for Kafka 0.10.2.0. We'll then continue to improve the MongoDB, MySQL, and PostgreSQL connectors and pushing out 0.5.x releases. Stay tuned and get involved!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve ours existing connectors and add even more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-03-27-Debezium-0-5-0-Released.adoc
+++ b/_posts/2017-03-27-Debezium-0-5-0-Released.adoc
@@ -21,11 +21,3 @@ Thanks to Sanjay and everyone in the community for their help with this release,
 == What's next
 
 We'll continue to improve the MongoDB, MySQL, and PostgreSQL connectors and pushing out 0.5.x releases with fixes. And we're still working on connectors for https://issues.redhat.com/browse/DBZ-40[SQL Server] and https://issues.redhat.com/browse/DBZ-137[Oracle]. Stay tuned and get involved!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams, so applications can see and respond almost instantly to each committed row-level change in the databases. Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems. Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running, ensuring that all events are processed correctly and completely. Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try. Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter], or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community. All of the code is open source https://github.com/debezium/[on GitHub], so build the code locally and help us improve ours existing connectors and add even more connectors. If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-06-12-debezium-0-5-1-released.adoc
+++ b/_posts/2017-06-12-debezium-0-5-1-released.adoc
@@ -39,20 +39,3 @@ In parallel we're looking into Debezium connectors for https://issues.redhat.com
 While we cannot promise anything yet in terms of when these will be ready to be published, we hope to have at least one of them ready some time soon.
 Stay tuned and get involved!
 
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-08-17-debezium-0-5-2-is-out.adoc
+++ b/_posts/2017-08-17-debezium-0-5-2-is-out.adoc
@@ -48,21 +48,3 @@ we've planned to explore support for Oracle and hopefully will do an initial rel
 In other words, exciting times are ahead!
 If you'd like to get involved, let us know.
 Check out the details below on how to get in touch.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-09-21-debezium-0-6-0-released.adoc
+++ b/_posts/2017-09-21-debezium-0-6-0-released.adoc
@@ -66,21 +66,3 @@ We'll likely also do further 0.6.x releases with bug fixes as required.
 You'd like to contribute?
 That's great - let us know and we'll get you started.
 Check out the details below on how to get in touch.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-09-25-streaming-to-another-database.adoc
+++ b/_posts/2017-09-25-streaming-to-another-database.adoc
@@ -267,21 +267,3 @@ And since it is a streaming system, it will continue to capture all changes made
 == What's next?
 
 In a future blog post we will reproduce the same scenario with Elasticsearch as a target for events.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-10-26-debezium-0-6-1-released.adoc
+++ b/_posts/2017-10-26-debezium-0-6-1-released.adoc
@@ -63,21 +63,3 @@ We've automated the release process as much as possible, making it a breeze to s
 If you'd like to contribute, please let us know.
 We're happy about any help and will work with you to get you started quickly.
 Check out the details below on how to get in touch.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-11-11-debezium-at-devoxx-belgium.adoc
+++ b/_posts/2017-11-11-debezium-at-devoxx-belgium.adoc
@@ -27,21 +27,3 @@ The slide deck is https://speakerdeck.com/gunnarmorling/streaming-database-chang
 <script async class="speakerdeck-embed" data-id="4fb7aa5af1c54d7ea807c9d46fb5b1fa" data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"></script>
 </div>
 ++++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-11-15-debezium-0-6-2-released.adoc
+++ b/_posts/2017-11-15-debezium-0-6-2-released.adoc
@@ -66,21 +66,3 @@ and so does the work on the Oracle connector (which will be shipping in a future
 If you'd like to contribute, please let us know.
 We're happy about any help and will work with you to get you started quickly.
 Check out the details below on how to get in touch.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-12-15-debezium-0-7-0-released.adoc
+++ b/_posts/2017-12-15-debezium-0-7-0-released.adoc
@@ -98,21 +98,3 @@ This will allow the user to re-configure the set of tables captured without need
 If you'd like to contribute, please let us know.
 We're happy about any help and will work with you to get you started quickly.
 Check out the details below on how to get in touch.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2017-12-20-debezium-0-7-1-released.adoc
+++ b/_posts/2017-12-20-debezium-0-7-1-released.adoc
@@ -18,21 +18,3 @@ We are outsmarted by the JDBC driver internals and included a distinct plugin de
 We have also gathered feedback from first tries to run with Amazon RDS and included link:/docs/connectors/postgresql/#amazon-rds[a short section] in our documentation on this topic.
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-01-17-streaming-to-elasticsearch.adoc
+++ b/_posts/2018-01-17-streaming-to-elasticsearch.adoc
@@ -283,21 +283,3 @@ Besides different applications of fulltext search one could for instance also th
 
 If you'd like to try out this set-up yourself, just clone the project from our https://github.com/debezium/debezium-examples/tree/master/unwrap-smt[examples repo].
 In case you need help, have feature requests or would like to share your experiences with this pipeline, please let us know in the comments below.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-01-25-debezium-0-7-2-released.adoc
+++ b/_posts/2018-01-25-debezium-0-7-2-released.adoc
@@ -105,21 +105,3 @@ We've also worked out link:/docs/roadmap/[a roadmap] describing our ideas for fu
 While nothing is cast in stone, this is our idea of the features to add in the coming months.
 If you miss anything important on this roadmap, please tell us either in the comments below or send a message to our Google group.
 Looking forward to your feedback!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-02-15-debezium-0-7-3-released.adoc
+++ b/_posts/2018-02-15-debezium-0-7-3-released.adoc
@@ -82,21 +82,3 @@ Please also our link:/docs/roadmap/[roadmap] describing our ideas for future dev
 This is our current thinking of the things we'd like to tackle in the coming months,
 but it's not cast in stone, so please let us know about your feature requests by sending a message to our Google group.
 We're looking forward to your feedback!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-03-07-debezium-0-7-4-released.adoc
+++ b/_posts/2018-03-07-debezium-0-7-4-released.adoc
@@ -72,21 +72,3 @@ Please also check out our link:/docs/roadmap/[roadmap] for the coming months of 
 This is our current plan for the things we'll work on,
 but it's not cast in stone, so please tell us about your feature requests by sending a message to our Google group.
 We're looking forward to your feedback!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-03-16-note-on-database-history-topic-configuration.adoc
+++ b/_posts/2018-03-16-note-on-database-history-topic-configuration.adoc
@@ -50,21 +50,3 @@ Alternatively, a complete new snapshot should be taken, e.g. by setting up a new
 We'll release Debezium 0.7.5 with a fix for this issue early next week.
 Note that previously created database history topics should be re-configured as described above.
 Please don't hesitate to get in touch in the comments below, the chat room or the mailing list in case you have any further questions on this issue.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-03-20-debezium-0-7-5-released.adoc
+++ b/_posts/2018-03-20-debezium-0-7-5-released.adoc
@@ -33,21 +33,3 @@ Please refer to the link:/docs/releases/#release-0-7-4[change log] for the compl
 
 Please see the link:/blog/2018/03/07/debezium-0-7-4-released/[previous release announcement] for the next planned features.
 Due to the unplanned 0.7.5 release, though, the schedule of the next one will likely be extended a little bit.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
+++ b/_posts/2018-05-24-querying-debezium-change-data-eEvents-with-ksql.adoc
@@ -298,21 +298,3 @@ If you'd like to try out this example with Avro encoding and schema registry the
 Also for further details and more advanced usages just refer to the KSQL https://github.com/confluentinc/ksql/blob/master/docs/syntax-reference.md[syntax reference].
 
 In case you need help, have feature requests or would like to share your experiences with this example, please let us know in the comments below.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-06-21-debezium-0-8-0-beta1-released.adoc
+++ b/_posts/2018-06-21-debezium-0-8-0-beta1-released.adoc
@@ -136,21 +136,3 @@ which might be shipped eventually.
 
 Please take a look at the link:/docs/roadmap/[roadmap] for some more long term ideas and get in touch with us,
 if you got thoughts around that.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-07-04-debezium-0-8-0-cr1-released.adoc
+++ b/_posts/2018-07-04-debezium-0-8-0-cr1-released.adoc
@@ -45,21 +45,3 @@ for which the first steps just have been made today by preparing a Docker-based 
 allowing to implement and test the connector in the following.
 
 To find out about some more long term ideas, please check out our link:/docs/roadmap/[roadmap] and get in touch with us, if you got any ideas or suggestions for future development.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-07-12-debezium-0-8-0-final-released.adoc
+++ b/_posts/2018-07-12-debezium-0-8-0-final-released.adoc
@@ -42,21 +42,3 @@ The other focus of work is a connector for SQL Server (see https://issues.redhat
 Work on this has started as well, and there should be an Alpha1 release of Debezium 0.9 with a first drop of that connector within the next few weeks.
 
 To find out about some more long term ideas, please check out our link:/docs/roadmap/[roadmap] and get in touch with us, if you got any ideas or suggestions for future development.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-07-19-advantages-of-log-based-change-data-capture.adoc
+++ b/_posts/2018-07-19-advantages-of-log-based-change-data-capture.adoc
@@ -64,21 +64,3 @@ If for instance your use case can be satisfied by propagating changes once per h
 But if you're interested in capturing data changes in near real-time, making sure you don't miss any change events (including deletions), then I'd recommend very much to explore the possibilities of log-based CDC as enabled by Debezium.
 The Debezium connectors do all the heavy-lifting for you, i.e. you don't have to deal with all the low-level specifics of the individual databases and the means of getting changes from their logs.
 Instead, you can consume the generic and largely unified change data events produced by Debezium.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-07-26-debezium-0-9-0-alpha1-released.adoc
+++ b/_posts/2018-07-26-debezium-0-9-0-alpha1-released.adoc
@@ -77,21 +77,3 @@ While some details are still unclear, we are optimistic to have something to rel
 
 If you'd like to learn more about some middle and long term ideas, please check out our link:/docs/roadmap/[roadmap].
 Also please get in touch with us if you got any ideas or suggestions for future development.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-08-30-debezium-0-8-2-released.adoc
+++ b/_posts/2018-08-30-debezium-0-8-2-released.adoc
@@ -37,21 +37,3 @@ and in the next step we've planned to move the existing Postgres connector to th
 
 If you'd like to learn more about some middle and long term ideas, please check out our link:/docs/roadmap/[roadmap].
 Also please get in touch with us if you got any ideas or suggestions for future development.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
+++ b/_posts/2018-08-30-streaming-mysql-data-changes-into-kinesis.adoc
@@ -420,21 +420,3 @@ Meaning you could connect the Debezium source connectors with your preferred str
 
 If you like this idea, then please check out JIRA issue https://issues.redhat.com/browse/DBZ-651[DBZ-651] and let us know about your thoughts,
 e.g. by leaving a comment on the issue, in the comment section below or on our https://groups.google.com/forum/#!forum/debezium[mailing list].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
+++ b/_posts/2018-09-19-debezium-0-8-3-final-released.adoc
@@ -72,21 +72,3 @@ If you are at any of these conferences, come and say Hi;
 we'd love to exchange with you about your use cases, feature requests, feedback on our link:/docs/roadmap/[roadmap] and any other ideas around Debezium.
 
 Finally, a big "Thank You" goes to our fantastic community members https://github.com/jchipmunk[Andrey Pustovetov], https://github.com/maver1ck[Maciej Bryński] and https://github.com/PengLyu[Peng Lyu] for their contributions to this release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
+++ b/_posts/2018-09-20-materializing-aggregate-views-with-hibernate-and-debezium.adoc
@@ -449,21 +449,3 @@ Also, this would be a great item to work on, if you're interested in contributin
 Looking forward to hearing from you, e.g. in the comment section below or on our https://groups.google.com/forum/#!forum/debezium[mailing list].
 
 Thanks a lot to Hans-Peter Grahsl for his feedback on an earlier version of this post!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
+++ b/_posts/2018-10-04-debezium-0-9-0-alpha2-released.adoc
@@ -109,21 +109,3 @@ We'll also be talking about Debezium at the following conferences:
 
 Already last week I had the opportunity to present Debezium at https://jug-saxony-day.org/programm/#!/P31[JUG Saxony Day].
 If you are interested, you can find the (German) https://speakerdeck.com/gunnarmorling/streaming-von-datenbankanderungen-mit-debezium-jug-saxony-day[slideset of that talk] on Speaker Deck.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-11-22-debezium-0-9-0-beta1-released.adoc
+++ b/_posts/2018-11-22-debezium-0-9-0-beta1-released.adoc
@@ -49,21 +49,3 @@ You can find the slides and recordings from https://kafka-summit.org/sessions/ch
 There you also can find the links to the slides of the great talk "The Why’s and How’s of Database Streaming" by Joy Gao of WePay, a Debezium user of the first hour,
 as well as the link to a blog post by Hans-Peter Grahsl about setting up a CDC pipeline from MySQL into Cosmos DB running on Azure.
 If you know about other great articles, session recordings or similar on Debezium and change data capture which should be added there, please let us know.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
+++ b/_posts/2018-12-05-automating-cache-invalidation-with-change-data-capture.adoc
@@ -501,21 +501,3 @@ and it could also be a very great project to work on, should you be interested i
 If you got any thoughts on this idea, please post a comment below or come to our https://groups.google.com/forum/#!forum/debezium[mailing list].
 
 Many thanks to Guillaume Smet, Hans-Peter Grahsl and Jiri Pechanec for their feedback while writing this post!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2018-12-19-debezium-0-9-0-beta2-released.adoc
+++ b/_posts/2018-12-19-debezium-0-9-0-beta2-released.adoc
@@ -102,21 +102,3 @@ we're looking forward to hearing from you.
 And with that, all that remains to be said, is https://en.wikipedia.org/wiki/Festivus["Happy Festivus for the rest of us!"]
 
 Happy change data streaming and see you in 2019!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-01-28-debezium-0-9-0-cr1-released.adoc
+++ b/_posts/2019-01-28-debezium-0-9-0-cr1-released.adoc
@@ -88,21 +88,3 @@ which will provide improvements and potential bugfixes to the features added in 
 
 For further plans beyond that, check out our link:/docs/roadmap/[road map].
 If you got any feedback or suggestions for future additions, please get in touch via the https://groups.google.com/forum/#!forum/debezium[mailing list] or in the comments below.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-02-05-debezium-0-9-0-final-released.adoc
+++ b/_posts/2019-02-05-debezium-0-9-0-final-released.adoc
@@ -112,21 +112,3 @@ If you're just about to begin using Debezium for streaming changes out of your d
 you might be interested in join us for the https://www.redhat.com/en/events/webinar/change-data-streaming-patterns-microservices-kafka-and-debezium[upcoming webinar] on February 7th.
 After a quick overview, you'll see Debezium in action, as it streams changes to a browser-based dashboard and more.
 You can also find lots of resources around Debezium and change data capture such as blog posts and presentations in our curated link:/docs/online-resources/[list of online resources].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-02-13-debezium-0-9-1-final-released.adoc
+++ b/_posts/2019-02-13-debezium-0-9-1-final-released.adoc
@@ -36,21 +36,3 @@ Altogether, https://issues.redhat.com/issues/?jql=project%20%3D%20DBZ%20AND%20fi
 Please refer to the link:/docs/releases/#release-0-9-1-final[release notes] to learn more about all fixed bugs, update procedures etc.
 
 Thanks a lot to community members https://github.com/ivan-lorenz[Ivan Lorenz] and https://github.com/tomazlemos[Tomaz Lemos Fernandes] for their contributions to this release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-02-13-debezium-webinar-at-devnation-live.adoc
+++ b/_posts/2019-02-13-debezium-webinar-at-devnation-live.adoc
@@ -34,21 +34,3 @@ You can also find the https://speakerdeck.com/gunnarmorling/change-data-streamin
 <script async class="speakerdeck-embed" data-id="c390d77e50464c99916ede7368a279c2" data-ratio="1.77777777777778" src="//speakerdeck.com/assets/embed.js"></script>
 </div>
 ++++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
+++ b/_posts/2019-02-19-reliable-microservices-data-exchange-with-the-outbox-pattern.adoc
@@ -738,21 +738,3 @@ This is to ensure to not accidentally break any consumers when upgrading the pro
 At the same time, consumers should be lenient when handling messages and for instance not fail when encountering unknown attributes within received events.
 
 _Many thanks to Hans-Peter Grahsl, Jiri Pechanec, Justin Holmes and René Kerner for their feedback while writing this post!_
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
+++ b/_posts/2019-02-25-debezium-0-9-2-final-released.adoc
@@ -51,21 +51,3 @@ which fixes a bug that had caused exceptions during rebalancing the connector be
 Check out the link:/docs/releases/#release-0-9-2-final[release notes] for the complete list of issues fixed in Debezium 0.9.2.
 
 Many thanks to Debezium community members https://github.com/jchipmunk[Andrey Pustovetov], https://github.com/kbarber2[Keith Barber], https://github.com/krizhan[Krizhan Mariampillai] and https://github.com/taylor-rolison[Taylor Rolison] for their contributions to this release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-03-14-debezium-meets-quarkus.adoc
+++ b/_posts/2019-03-14-debezium-meets-quarkus.adoc
@@ -206,21 +206,3 @@ If you got any questions or feedback, please let us know in the comments below;
 looking forward to hearing from you!
 
 _Many thanks to Guillaume Smet for reviewing an earlier version of this post!_
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
+++ b/_posts/2019-03-26-debezium-0-9-3-final-released.adoc
@@ -51,21 +51,3 @@ It is now possible to process multiple schemas with a single Oracle connector (h
 Check out the link:/docs/releases/#release-0-9-3-final[release notes] for the complete list of issues fixed in Debezium 0.9.3.
 
 Many thanks to Debezium community members https://github.com/renatomefi[Renato Mefi], https://github.com/ShubhamRwt[Shubham Rawat], https://github.com/addisonj[Addison Higham], https://github.com/jcasstevens[Jon Casstevens], https://github.com/hashhar[Ashar Hassan] and https://github.com/p5k6[Josh Stanfield] for their contributions to this release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-04-11-debezium-0-9-4-final-released.adoc
+++ b/_posts/2019-04-11-debezium-0-9-4-final-released.adoc
@@ -46,21 +46,3 @@ https://github.com/sashakovryga[Sasha Kovryga],
 https://github.com/ShubhamRwt[Shubham Rawat] and
 https://github.com/Crim[Stephen Powis]
 for their contributions to this release!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-05-06-debezium-0-9-5-final-released.adoc
+++ b/_posts/2019-05-06-debezium-0-9-5-final-released.adoc
@@ -60,21 +60,3 @@ We believe users will benefit from a more consistent experience across the conne
 
 Another focus area will be to migrate the existing Postgres connector to the framework classes established for the SQL Server and Oracle connectors.
 This will allow to expose some new features for the Postgres connector, e.g. the monitoring capabilities already rolled out for the other two connectors.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-05-29-debezium-0-10-0-alpha1-released.adoc
+++ b/_posts/2019-05-29-debezium-0-10-0-alpha1-released.adoc
@@ -104,21 +104,3 @@ We'll also continue our efforts to to migrate the existing Postgres connector to
 Another thing we're actively exploring is how the Postgres could take advantage of the "logical replication" feature added in Postgres 10.
 This may provide us with a way to ingest change events without requiring a custom server-side logical decoding plug-in,
 which proves challenging in cloud environments where there's typically just a limited set of logical decoding options available.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-06-03-debezium-0-10-0-alpha2-released.adoc
+++ b/_posts/2019-06-03-debezium-0-10-0-alpha2-released.adoc
@@ -28,21 +28,3 @@ https://github.com/barrti[Bartosz Miedlar] has fixed a bug in MySQL ANTLR gramma
 We hope we will be able to keep the recent release cadence and get lout the first beta version of 0.10 in two weeks.
 
 Stay tuned for more!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-06-12-debezium-0-10-0-beta1-released.adoc
+++ b/_posts/2019-06-12-debezium-0-10-0-beta1-released.adoc
@@ -24,21 +24,3 @@ Also make sure to examine the upgrade guidelines for 0.10.0.Alpha1 and Alpha2 wh
 Many thanks to community members https://github.com/pan3793[Cheng Pan] and https://github.com/ChingTsai[Ching Tsai] for their contributions to this release!
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-06-19-debezium-wears-fedora.adoc
+++ b/_posts/2019-06-19-debezium-wears-fedora.adoc
@@ -169,21 +169,3 @@ We're still in the process of exploring the implications (and possible limitatio
 but so far things look promising and it may eventually be a valuable tool to have in the box.
 
 Stay tuned for more details coming soon!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-06-28-debezium-0-10-0-beta2-released.adoc
+++ b/_posts/2019-06-28-debezium-0-10-0-beta2-released.adoc
@@ -41,21 +41,3 @@ https://github.com/pan3793[Cheng Pan],
 https://github.com/willome[Guillaume Rosauro],
 https://github.com/szczeles[Mariusz Strzelecki] and
 https://github.com/ssouris[Stathis Souris].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
+++ b/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
@@ -139,21 +139,3 @@ Thanks to the recent refactor of the Debezium container images, it got very easy
 Downloading external dependencies and adding them to the images became a trivial task and we'd love to hear your feedback about it!
 
 If you are curious about the refactoring itself, you can find the details in pull request https://github.com/debezium/docker-images/pull/131[debezium/docker-images#131].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-07-25-debezium-0-10-0-beta3-released.adoc
+++ b/_posts/2019-07-25-debezium-0-10-0-beta3-released.adoc
@@ -46,21 +46,3 @@ https://github.com/addisonj[Addison Higham],
 https://github.com/BinLi1988[Bin Li],
 https://github.com/brbrown25[Brandon Brown] and
 https://github.com/renatomefi[Renato Mefi].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-08-20-debezium-0-10-0-beta4-released.adoc
+++ b/_posts/2019-08-20-debezium-0-10-0-beta4-released.adoc
@@ -77,21 +77,3 @@ A big thank you goes out to all the contributors from the Debezium community who
 https://github.com/jgao54[Joy Gao],
 https://github.com/renatomefi[Renato Mefi] and
 https://github.com/willome[Guillaume Rosauro]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-09-10-debezium-0-10-0-cr1-released.adoc
+++ b/_posts/2019-09-10-debezium-0-10-0-cr1-released.adoc
@@ -79,22 +79,3 @@ https://github.com/willome[Guillaume Rosauro],
 https://github.com/ivanobulo[Ivan Luzyanin],
 https://github.com/levzem[Lev Zemlyanov] and
 https://github.com/renatomefi[Renato Mefi]!
-
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-09-26-debezium-0-10-0-cr2-released.adoc
+++ b/_posts/2019-09-26-debezium-0-10-0-cr2-released.adoc
@@ -105,21 +105,3 @@ https://github.com/josharenberg[Josh Arenberg] and
 https://github.com/taylor-rolison[Taylor Rolison].
 
 Many thanks to all of you!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
+++ b/_posts/2019-10-01-audit-logs-with-change-data-capture-and-stream-processing.adoc
@@ -679,21 +679,3 @@ To get started with your own implementation,
 you can check out https://github.com/debezium/debezium-examples/tree/master/auditlog[the code] in the Debezium examples repository on GitHub.
 
 _Many thanks to https://twitter.com/crancran77[Chris Cranford], https://twitter.com/hpgrahsl[Hans-Peter Grahsl], https://twitter.com/hashhar[Ashhar Hasan], pass:[<a href="https://twitter.com/jbfletch_">Anna McDonald</a>] and Jiri Pechanec for their feedback while working on this post and the accompanying example code!_
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-10-02-debezium-0-10-0-final-released.adoc
+++ b/_posts/2019-10-02-debezium-0-10-0-final-released.adoc
@@ -65,21 +65,3 @@ going forward, we'd like to increase the release cadence and publish new minor r
 Any contributions, input on the roadmap and other feedback will be very welcomed of course.
 
 Upwards and onwards!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-10-08-handling-unchanged-postgres-toast-values.adoc
+++ b/_posts/2019-10-08-handling-unchanged-postgres-toast-values.adoc
@@ -308,21 +308,3 @@ Or perhaps you have even further alternatives in mind?
 Tell us about it in the comments below.
 
 _Many thanks to https://twitter.com/dave_cramer/[Dave Cramer] and Jiri Pechanec for their feedback while working on this post and the accompanying example code!_
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-10-17-debezium-1-0-0-beta1-released.adoc
+++ b/_posts/2019-10-17-debezium-1-0-0-beta1-released.adoc
@@ -27,21 +27,3 @@ Thanks to all the community members who helped make this happen:
 https://github.com/pushpavanthar[Purushotham Pushpavanthar],
 https://github.com/jfinsel[Jeremy Finzel],
 https://github.com/grantcooksey[Grant Cooksey]
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-10-24-debezium-1-0-0-beta2-released.adoc
+++ b/_posts/2019-10-24-debezium-1-0-0-beta2-released.adoc
@@ -30,21 +30,3 @@ Thanks to all the community members who helped make this happen:
 https://github.com/grantcooksey[Grant Cooksey],
 https://github.com/mincong-h[Mingcong Huang],
 https://github.com/navdeep710[navdeep710]
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-11-14-debezium-1-0-0-beta3-released.adoc
+++ b/_posts/2019-11-14-debezium-1-0-0-beta3-released.adoc
@@ -37,21 +37,3 @@ https://github.com/jfinzel[Jeremy Finzel],
 https://github.com/datumgeek[Mike Graham],
 Yang Yang,
 Addison Higham
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-12-12-debezium-1-0-0-cr1-released.adoc
+++ b/_posts/2019-12-12-debezium-1-0-0-cr1-released.adoc
@@ -46,21 +46,3 @@ Perhaps we can bump this number to 200 in 2020?
 Barring any unforeseen issues, this candidate release should be the only one for Debezium 1.0,
 and the final version should be in your hands before Christmas.
 So please give the CR a try and let us know how it works for you!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2019-12-18-debezium-1-0-0-final-released.adoc
+++ b/_posts/2019-12-18-debezium-1-0-0-final-released.adoc
@@ -133,21 +133,3 @@ This is great news for folks who wish to have commercial support by Red Hat for 
 For now, let's celebrate the release of Debezium 1.0 and look forward to what's coming in 2020.
 
 Onwards and Upwards!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-01-16-debezium-1-1-alpha1-released.adoc
+++ b/_posts/2020-01-16-debezium-1-1-alpha1-released.adoc
@@ -119,21 +119,3 @@ Many thanks to https://github.com/oscerd[Andrea Cosentino], https://github.com/v
 
 Going forward, we'll continue with further Debezium 1.1 preview releases every two to three weeks.
 Take a look at the link:/roadmap/[roadmap] to see what's coming up, or get in touch to tell us about your specific feature requirements!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-02-11-debezium-1-1-beta1-released.adoc
+++ b/_posts/2020-02-11-debezium-1-1-beta1-released.adoc
@@ -119,21 +119,3 @@ for their contributions to this release!
 
 On our road towards Debezium 1.1, we'll likely do another Beta release before going to the candidate release phase in a few weeks from now.
 To see what's coming, take a look at the link:/roadmap/[roadmap], or get in touch to tell us about your specific feature requirements!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-02-13-debezium-1-1-beta2-released.adoc
+++ b/_posts/2020-02-13-debezium-1-1-beta2-released.adoc
@@ -65,21 +65,3 @@ https://github.com/jpsoroulas[John Psoroulas],
 https://github.com/matzew[Matthias Wessendorf],
 https://github.com/mwinstanley[Melissa Winstanley],
 as well as https://github.com/bsideup/[Sergei Egorov] for his advice on the Testcontainers work.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-02-19-debezium-camel-integration.adoc
+++ b/_posts/2020-02-19-debezium-camel-integration.adoc
@@ -286,21 +286,3 @@ Without the need for any external messaging infrastructure, it is very easy to d
 Camel equips the developer with a full arsenal of enterprise integration pattern implementations, as well as more than hundred connectors for different systems that could be included in a complex service orchestration.
 
 The source code of the full example is available https://github.com/debezium/debezium-examples/tree/master/camel-component[on GitHub].
-
-== About Debezium
-
-Debezium is an open-source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open-source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve our existing connectors and add even more connectors.
-If you find problems or have an idea on how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-03-13-debezium-1-1-c1-released.adoc
+++ b/_posts/2020-03-13-debezium-1-1-c1-released.adoc
@@ -156,21 +156,3 @@ For plans for future versions please refer to the link:/roadmap/[roadmap] and le
 Our general plan is to adopt a cadence of quarterly minor releases,
 i.e. you can expect Debezium 1.2 in about three months from now,
 1.3 in Q3 and so on.
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-03-19-integration-testing-for-change-data-capture-with-testcontainers.adoc
+++ b/_posts/2020-03-19-integration-testing-for-change-data-capture-with-testcontainers.adoc
@@ -240,21 +240,3 @@ ensuring the correctness of your data pipeline end-to-end.
 
 What's your take on testing CDC set-ups and pipelines?
 Let us know in the comments below!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-03-24-debezium-1-1-final-released.adoc
+++ b/_posts/2020-03-24-debezium-1-1-final-released.adoc
@@ -85,21 +85,3 @@ Check out the link:/roadmap/[roadmap] to learn more;
 one key feature will be a "standalone mode" for running Debezium independently of Kafka Connect,
 allowing to feed change events to other messaging infrastructure such as Amazon Kinesis.
 Also make sure to let us know about your suggestions, requirements and feature requests!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-04-09-using-debezium-wit-apicurio-api-schema-registry.adoc
+++ b/_posts/2020-04-09-using-debezium-wit-apicurio-api-schema-registry.adoc
@@ -628,21 +628,3 @@ In this article we discussed multiple approaches to message/schema association.
 The Apicurio registry was presented as a solution for schema sotrage and versioning and we have demonstrated how Apicurio can be integrated with Debezium connectors to efficiently deliver messages with schema to the consumer.
 
 You can find a complete example for using the Debezium connectors together with the Apicurio registry in the https://github.com/debezium/debezium-examples/tree/master/tutorial#using-mysql-and-apicurio-registry[tutorial] project of the Debezium examples repository on GitHub.
-
-== About Debezium
-
-Debezium is an open-source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open-source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve our existing connectors and add even more connectors.
-If you find problems or have an idea on how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-04-16-debezium-1-2-alpha1-released.adoc
+++ b/_posts/2020-04-16-debezium-1-2-alpha1-released.adoc
@@ -146,21 +146,3 @@ https://github.com/JanHendrikDolling[Jan-Hendrik Dolling],
 https://github.com/lga-zurich[Luis Garcés-Erice],
 https://github.com/devzer01[Nayana Hettiarachchi] and
 https://github.com/rk3rn3r[René Kerner]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-05-07-debezium-1-2-beta1-released.adoc
+++ b/_posts/2020-05-07-debezium-1-2-beta1-released.adoc
@@ -170,21 +170,3 @@ https://github.com/jhuiting[Jos Huiting],
 https://github.com/jgao54[Joy Gao]
 https://github.com/lyidataminr[lyidataminr], and
 https://github.com/TechnocratSid[Siddhant Agnihotry]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-05-19-debezium-1-2-beta2-released.adoc
+++ b/_posts/2020-05-19-debezium-1-2-beta2-released.adoc
@@ -77,21 +77,3 @@ https://github.com/jgao54[Joy Gao],
 https://github.com/jantpedraza[Juan Antonio Pedraza],
 https://github.com/kaplanmaxe[Max Kaplan], and
 https://github.com/crazy-2020[Xuan Shen]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-06-11-debezium-1-2-cr1-released.adoc
+++ b/_posts/2020-06-11-debezium-1-2-cr1-released.adoc
@@ -38,21 +38,3 @@ https://github.com/metlos[Lukas Krejci], and
 https://github.com/RobertHana[Robert B. Hanviriyapunt].
 
 +++<!-- more -->+++
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-06-24-debezium-1-2-final-released.adoc
+++ b/_posts/2020-06-24-debezium-1-2-final-released.adoc
@@ -105,21 +105,3 @@ The things we've planned so far include more flexible options for snapshotting (
 moving Db2 connector out of incubating state, and an exploration of what it'd take to officially support MariaDB.
 
 Onwards and upwards!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-07-16-debezium-1-2-1-final-released.adoc
+++ b/_posts/2020-07-16-debezium-1-2-1-final-released.adoc
@@ -39,21 +39,3 @@ https://github.com/keweishang[Kewei Shang],
 https://github.com/michaelwang[Michael Wang],
 https://github.com/omarsmak[Omar Al-Safi], and
 https://github.com/rhauch[Randall Hauch]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-08-06-debezium-1-3-alpha1-released.adoc
+++ b/_posts/2020-08-06-debezium-1-3-alpha1-released.adoc
@@ -81,22 +81,3 @@ https://github.com/grzegorz8[Grzegorz Kołakowski],
 https://github.com/bjoernhaeuser[Björn Häuser],
 https://github.com/korzenek[Lukasz Korzeniowski], and
 https://github.com/jonaslins[Jonas Lins]!
-
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-09-03-debezium-1-3-beta1-released.adoc
+++ b/_posts/2020-09-03-debezium-1-3-beta1-released.adoc
@@ -90,21 +90,3 @@ And a brand-new connector contributed by the community is showing up on the hori
 https://bolt.eu/en/[Bolt] engineers https://github.com/keweishang[Kewei Shang] and https://github.com/rgibaiev[Ruslan Gibaiev] have been working on a https://github.com/debezium/debezium-connector-vitess/pull/1[CDC connector for the Vitess database] and announced that they'd like to open-source and continue to evolve it under the Debezium umbrella.
 
 Exciting times for open-source change data capture and Debezium 🎉!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-09-15-debezium-auto-create-topics.adoc
+++ b/_posts/2020-09-15-debezium-auto-create-topics.adoc
@@ -225,21 +225,3 @@ shows how to use it with Debezium.
 
 You can find an example https://github.com/debezium/debezium-examples/tree/master/topic-auto-create[here]
 in the Debezium examples repository on GitHub.
-
-== About Debezium
-
-Debezium is an open-source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open-source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve our existing connectors and add even more connectors.
-If you find problems or have an idea on how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-09-16-debezium-1-3-beta2-released.adoc
+++ b/_posts/2020-09-16-debezium-1-3-beta2-released.adoc
@@ -86,21 +86,3 @@ with the Debezium 1.3 Final release to be expected around the end of the month.
 
 In parallel, work is happening on a https://github.com/debezium/debezium-connector-vitess/pull/1[new connector] contributed by the community for the Vitess (which will - depending on progress of review - be released as an incubating connector either in Debezium 1.3 or 1.4),
 and we're going to share some exciting efforts around a proof-of-concept for a potential future Debezium UI with you very soon!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-09-24-debezium-1-3-cr1-released.adoc
+++ b/_posts/2020-09-24-debezium-1-3-cr1-released.adoc
@@ -66,22 +66,3 @@ Barring any unforeseen regressions and bug reports, Debezium 1.3 Final should be
 Until then, we'll focus on some more polishing.
 The https://github.com/debezium/debezium-connector-vitess/pull/1[community-lead work] towards a Debezium connector for https://vitess.io/[Vitess] is also making good progress,
 with an initial release of this new connector planned with Debezium 1.4 Alpha1 in late October.
-
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-10-01-debezium-1-3-final-released.adoc
+++ b/_posts/2020-10-01-debezium-1-3-final-released.adoc
@@ -86,21 +86,3 @@ We've got quite a few ideas in that field and will share more details in a blog 
 If you feel adventureous in the meantime, you could grab the https://github.com/debezium/debezium-ui-poc/[current PoC code] and take it for spin!
 
 Until then, happy change data streaming, onwards and upwards!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-10-08-debezium-community-stories-with-renato-mefi.adoc
+++ b/_posts/2020-10-08-debezium-community-stories-with-renato-mefi.adoc
@@ -135,21 +135,3 @@ And that's where I put my energy in everyday at work, giving all the engineering
 *Renato, thanks a lot for taking your time, it was a pleasure to have you here!*
 
 _If you'd like to stay in touch with Renato Mefi and discuss with him, please drop a comment below or follow and reach out to him https://twitter.com/renatomefi[on Twitter]._
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-10-22-towards-debezium-ui.adoc
+++ b/_posts/2020-10-22-towards-debezium-ui.adoc
@@ -73,21 +73,3 @@ We're looking forward very much to learning about your feedback on the Debezium 
 Try it out yourself and let us know about your thoughts in the comments below and by participating in the quick survey linked above.
 
 _A big thank you to the team working on this PoC: Ashique Ansari, Indra Shukla, June Zhang, Mark Drilling, Na Ding, and René Kerner!_
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-10-23-debezium-1-4-alpha1-released.adoc
+++ b/_posts/2020-10-23-debezium-1-4-alpha1-released.adoc
@@ -83,21 +83,3 @@ https://github.com/johnjmartin[John Martin],
 https://github.com/telnicky[Travis Elnicky],
 https://github.com/yimingl17[Yiming Liu], and
 https://github.com/bingqinzhou[Bingqin Zhou]!
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-11-12-debezium-1-3-1-final-released.adoc
+++ b/_posts/2020-11-12-debezium-1-3-1-final-released.adoc
@@ -34,22 +34,3 @@ Please refer to the link:/releases/1.3/release-notes/#release-1.3.1-final[releas
 
 A big thank you to everyone who helped test and identify these bugs.
 The team appreciates the invaluable feedback the community continually provides!
-
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].

--- a/_posts/2020-11-17-debezium-1-4-alpha2-released.adoc
+++ b/_posts/2020-11-17-debezium-1-4-alpha2-released.adoc
@@ -85,21 +85,3 @@ https://github.com/zrlurb[Peter Urbanetz],
 https://github.com/rareddy[Ramesh Reddy],
 https://github.com/morozov[Sergei Morozov], and
 https://github.com/ramanenka[Vadzim Ramanenka].
-
-== About Debezium
-
-Debezium is an open source distributed platform that turns your existing databases into event streams,
-so applications can see and respond almost instantly to each committed row-level change in the databases.
-Debezium is built on top of http://kafka.apache.org/[Kafka] and provides http://kafka.apache.org/documentation.html#connect[Kafka Connect] compatible connectors that monitor specific database management systems.
-Debezium records the history of data changes in Kafka logs, so your application can be stopped and restarted at any time and can easily consume all of the events it missed while it was not running,
-ensuring that all events are processed correctly and completely.
-Debezium is link:/license/[open source] under the http://www.apache.org/licenses/LICENSE-2.0.html[Apache License, Version 2.0].
-
-== Get involved
-
-We hope you find Debezium interesting and useful, and want to give it a try.
-Follow us on Twitter https://twitter.com/debezium[@debezium], https://gitter.im/debezium/user[chat with us on Gitter],
-or join our https://groups.google.com/forum/#!forum/debezium[mailing list] to talk with the community.
-All of the code is open source https://github.com/debezium/[on GitHub],
-so build the code locally and help us improve ours existing connectors and add even more connectors.
-If you find problems or have ideas how we can improve Debezium, please let us know or https://issues.redhat.com/projects/DBZ/issues/[log an issue].


### PR DESCRIPTION
Addresses issue #551 

- add 'About Debezium' and 'Get involved' sections into the blog post template, underneath the author block
- remove the repeated section from all of the blog post asciidocs