### PR TITLE
Adding button to move to next and previous blog

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -119,7 +119,23 @@ layout: base
       </div>
     </div>
     {% endfor %}
-      
+
+      <ul class="pager pager-blog">
+        {% if page.previous.url %}
+          <li class="previous">
+            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous post</a>
+        </li>
+        {% else %}
+          <li class="previous disabled">
+            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous post</a>
+          </li>
+        {% endif %}        
+        {% if page.next.url %}
+        <li class="next"><a href="{{page.next.url}}">Next post &raquo; </a></li>
+        {% else %}
+          <li class="next disabled"><a href="{{page.next.url}}">Next post &raquo; </a></li>
+        {% endif %}
+      </ul>
     
     {% endif %}
     <div class="row">
@@ -149,6 +165,7 @@ layout: base
         </p>
       </div>
     </div>
+    
     {% if site.disqus.shortname and jekyll.environment == 'production' %}
       {% include disqus_comments.html %}
     {% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -123,17 +123,17 @@ layout: base
       <ul class="pager pager-blog">
         {% if page.previous.url %}
           <li class="previous">
-            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous post</a>
+            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous</a>
         </li>
         {% else %}
           <li class="previous disabled">
-            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous post</a>
+            <a href="{{page.previous.url}}" class="previous"> &laquo; Previous</a>
           </li>
         {% endif %}        
         {% if page.next.url %}
-        <li class="next"><a href="{{page.next.url}}">Next post &raquo; </a></li>
+        <li class="next"><a href="{{page.next.url}}">Next &raquo; </a></li>
         {% else %}
-          <li class="next disabled"><a href="{{page.next.url}}">Next post &raquo; </a></li>
+          <li class="next disabled"><a href="{{page.next.url}}">Next &raquo; </a></li>
         {% endif %}
       </ul>
     

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -10852,3 +10852,6 @@ span.test-with-subcategory {
   font-style: italic;
   color: #8f8f8f;
 }
+.pager-blog {
+  margin-bottom: 0px !important;
+}


### PR DESCRIPTION
- Added the blog navigation option to move to "next" and "previous" posts from the blog page itself.

Screenshot 
![image](https://user-images.githubusercontent.com/8264372/100088159-bc4ac480-2e75-11eb-8fc7-6bc2fb679c30.png)
