### PR TITLE
Fix SQL Server artifact download link

### DIFF
--- a/_includes/release-version.html
+++ b/_includes/release-version.html
@@ -136,7 +136,7 @@
             </li>
             <li>
               <a
-                href="https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{{releaseDetails[subVersion].version}}.Final/debezium-connector-sqlserver-{{releaseDetails[subVersion].version}}-plugin.tar.gz"
+                href="https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/{{releaseDetails[subVersion].version}}/debezium-connector-sqlserver-{{releaseDetails[subVersion].version}}-plugin.tar.gz"
                 >SQL Server Connector Plug-in</a
               >
             </li>


### PR DESCRIPTION
Removes the unnecessary `.Final` text from the SQL Server download link from the releases page.