### PR TITLE
DBZ-3124 Upgrade Vitess gRPC client version to 9.0.0 for Enum support

### DIFF
--- a/_data/releases/1.5/series.yml
+++ b/_data/releases/1.5/series.yml
@@ -83,5 +83,5 @@ compatibility:
         - 9.0.x
     driver:
       versions:
-        - 7.0.0
+        - 9.0.0
     note: See the Vitess Connector <a href="/documentation/reference/1.5/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-3124

The Vitess gRPC client version 9.0.0 has the additional gRPC field that contains Enum's permitted values.

Related PRs:

- Feature implementation: https://github.com/debezium/debezium-connector-vitess/pull/20
- Vitess Connector documentation: https://github.com/debezium/debezium/pull/2142