### PR TITLE
Readme updates

### DIFF
--- a/ANTORA.md
+++ b/ANTORA.md
@@ -4,7 +4,7 @@ Debezium now makes use of the [Antora framework](http://www.antora.org) to build
 
 ## How it works
 
-The build process now includes one additional step prior to calling jekyll, which is to call:
+The build process now includes one additional step prior to calling Jekyll, which is to call:
 
 ```
 antora playbook.yml
@@ -19,29 +19,34 @@ The Debezium Antora integration currently uses the [antora-default-ui](https://g
 ## Running Antora manually
 
 There are times where one may find it useful to regenerate just the Antora documentation while running the website in preview mode.
-In order to run Antora manually, simply open a bash session to the already running Jekyll docker container:
+
+You must first start the docker container for previewing the website, as described in this [README section](./README.md#22-using-the-container-image---generate-debezium-docs-from-local-repo).  If you want Antora to generate docs from your local Debezium repo, it is **important** to include the volume mapping for the local Debezium repo as described.
+
+To run Antora manually, simply open a bash session to the already running website-builder container:
 
 ```
-docker exec -it <dynamic name of jekyll container> bash
+docker exec -it website-builder bash
 ```
 
-Once in the container, navigate to the `/site` directory and execute:
+Once in the container, navigate to the `/site` directory.
+
+To regenerate the documentation from the local checked-out copy of the Debezium repo (author mode), enter the following.
+
 
 ```
 antora playbook_author.yml
 ```
-or
+
+To regenerate the documentation by cloning the remote Debezium repository from GitHub, enter the following:
+
 
 ```
 antora playbook.yml
 ```
 
-The author mode regenerates the site from a local checked out copy of the Debezium repository, which in most cases is exactly what you'd want.
-The non-author mode regenerates the site by cloning the remote Debezium repository from Github.
-
 ## Release process
 
-What is important for the release process is to make sure that the `playbook.yml` file references the correct branches or tags for building the Debezium documentation on github pages that also aligns with the displayed series (See CONTRIBUTING.md for more details on series configuration). For example, if series `0.8`, `0.9`, and `0.10` are all displayed, then Antora should technically be building 3 differing combinations of either branches or tags.
+What is important for the release process is to make sure that the `playbook.yml` file references the correct branches or tags for building the Debezium documentation on GitHub pages that also aligns with the displayed series (See CONTRIBUTING.md for more details on series configuration). For example, if series `0.8`, `0.9`, and `0.10` are all displayed, then Antora should technically be building 3 differing combinations of either branches or tags.
 
 In `playbook.yml`, the `content` section is what drives what branch/tags will be rendered.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The latter is a bit quicker, but requires Ruby/Jekyll to be set up correctly, wh
 
 In a new terminal initialized with the Docker host environment, start a Docker container that has the build environment for our website:
 
-    $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site debezium/website-builder bash
+    $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site --name website-builder debezium/website-builder bash
 
 This command tells Docker to start a container using the `debezium/website-builder` image (downloading it if necessary) with an interactive terminal (via `-it` flag) to the container so that you will see the output of the process running in the container. The `--rm` flag will remove the container when it stops, while the `-p 4000` flag maps the container's 4000 port to the same port on the Docker host (which is the local machine on Linux or the virtual machine if running Boot2Docker or Docker Machine on OS X and Windows). The `-v $(pwd):/site` option mounts your current working directory (where the website's code is located) into the `/site` directory within the container.
 
@@ -58,10 +58,32 @@ This should only need to be performed once. After the libraries are installed, w
 
     jekyll@49d06009e1fa:/site$ rake clean preview
     
-With the integration with Antora, the above command will now also fetch the main codebase repository and will invoke the Antora build process to build the version-specific documentation prior to invoking Jekyll.  For information on Antora and how we've integrated it into the build process, please see [ANTORA.md](./ANTORA.md).
-Also see [CONTRIBUTING.md](./CONTRIBUTING.md) to learn about running the Antora build based on a local check out of the main codebase instead of fetching it from upstream.s
+The site generation process is integrated with Antora.  Antora generates the version-specific documentation from the main Debezium GitHub repository, and is invoked prior to Jekyll for inclusion in the website.  The default mode using the above commands will fetch the Debezium codebase from GitHub.  If you wish to generate the Debezium documentation using your local Debezium git repository, see the next section. For more specifics on the Antora build, please see [ANTORA.md](./ANTORA.md)
 
-##### 2.2 Using a local Ruby and Jekyll installation
+#### 2.2 Using the container image - (generate Debezium docs from local repo)
+
+The default process (outlined in the previous section) will generate the Debezium version-specific documentation from the Debezium repository on GitHub.  However you may want to view or edit the documentation found in your local Debezium git repository.  In this case, the steps are slightly different.
+
+First, you must have a local clone of the [Debezium repository](https://github.com/debezium/debezium).
+
+Then start the Docker container:
+
+    $ docker run --privileged -it --rm -p 4000:4000 -e LC_ALL=C.UTF-8 -e LANG=C.UTF-8 -v $(pwd):/site -v ~/<PATH_TO_REPOS>/debezium:/debezium --name website-builder debezium/website-builder bash
+
+**Note** the addition of the volume mapping **-v ~/<PATH_TO_REPO_DIR>/debezium:/debezium**  -  ( replace <PATH_TO_REPO_DIR> with the actual location on your system ).
+
+Next, in the shell in the container, run the following commands to update and then (re)install all of the Ruby libraries required by the website:
+
+    jekyll@49d06009e1fa:/site$ bundle update
+    jekyll@49d06009e1fa:/site$ bundle install
+
+This should only need to be performed once. After the libraries are installed, we can then build the site from the code so you can preview it in a browser:
+
+    jekyll@49d06009e1fa:/site$ rake clean author preview
+
+The additional **author** arg above sets the environment to use *playbook_author.yml* instead of *playbook.yml* for Antora, which then builds the Debezium docs from the local repo. For more specifics on the Antora build, please see [ANTORA.md](./ANTORA.md)
+
+#### 2.3 Using a local Ruby and Jekyll installation
 
 Run the following steps once to set up your local Jekyll installation.
 


### PR DESCRIPTION
readme updates - attempting to clarify how to build debezium docs using local debezium repo when previewing the website. 

In the main readme, I added a section which is specific to building docs using local debezium repo, since it requires a few differences (getting clone of the repo, adding a volume mapping for debezium repo, and using the 'author' option in the rake command)

In the antora readme, I referred back to the main readme and the importance of adding the volume mapping when building from local repo.