### PR TITLE
Adding separate field to provide summary for release series

### DIFF
--- a/_data/releases/0.10/series.yml
+++ b/_data/releases/0.10/series.yml
@@ -1,5 +1,6 @@
 summary: Version 0.10 release stream
 version: "0.10"
+overview: New incubating Cassandra connector, new features and enhancements for PostgreSQL connector, and various bugfixes
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/0.9/series.yml
+++ b/_data/releases/0.9/series.yml
@@ -1,5 +1,6 @@
 summary: Version 0.9 release stream
 version: "0.9"
+overview: Introduces new SQL Server connector, improvement to Oracle and other connector.
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.0/series.yml
+++ b/_data/releases/1.0/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.0 release stream
 version: "1.0"
+overview: Support for and images based on Java 11, upgrade to Kafka 2.4. Locking timeout for MySQL snapshots.
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.1/series.yml
+++ b/_data/releases/1.1/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.1 release stream
 version: "1.1"
+overview: Debezium Quarkus extension. Public API for Debezium Engine, custom data converters and DB2 Connector preview.
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.2/series.yml
+++ b/_data/releases/1.2/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.2 release stream
 version: "1.2"
+overview: Embedded Engine SMT and converter support, Google Cloud Pub/Sub support in Debezium Server, Test stabilization
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.3/series.yml
+++ b/_data/releases/1.3/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.3 release stream
 version: "1.3"
+overview: Sink adapter support for Azure Event Hubs and Oracle LogMiner support. Logging in Connect image configurable via environment variables.
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.4/series.yml
+++ b/_data/releases/1.4/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.4 release stream
 version: "1.4"
+overview: Vitess connector support and full support of Oracle JDBC connection strings.
 displayed: false
 hidden: false
 tutorial: true

--- a/_data/releases/1.5/series.yml
+++ b/_data/releases/1.5/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.5 release stream
 version: "1.5"
+overview: MySQL connector rewrite, Redis Streams Sink in Debezium Server and Upgrade to Kafka 2.7
 displayed: true
 hidden: false
 tutorial: true

--- a/_data/releases/1.6/series.yml
+++ b/_data/releases/1.6/series.yml
@@ -1,5 +1,6 @@
 summary: Version 1.6 release stream
 version: "1.6"
+overview: Kafka Sink for Debezium Server, Incremental snapshotting for MySQL, PostgreSQL, Db2 and SQL Server Connectors.
 displayed: true
 hidden: false
 tutorial: true

--- a/_includes/release.html
+++ b/_includes/release.html
@@ -7,11 +7,9 @@
    {%- assign sortedReleaseDetails = releaseDetails | sort -%}
     {%- assign lastIndex = sortedReleaseDetails.size | minus: 2 -%}
     {% assign formattedLastVersion = sortedReleaseDetails[lastIndex][0] %}
-    {% assign formattedFirstVersion = sortedReleaseDetails[0][0] %}
 
     
     {% assign latestRelease = releaseDetails[formattedLastVersion] %}
-    {% assign firstRelease = releaseDetails[formattedFirstVersion] %}
     {% if latestRelease.stable %}
       {% assign labelStyle = "span label label-stable" %}
       {% assign labelText = "stable" %}
@@ -29,7 +27,7 @@
         <div class="clear"></div>
         <h3 class="version">{{ version }}</h3>
         <h6 class="version-date">{{ latestRelease.date }}</h6>
-        <div class="description">{{ firstRelease.summary | truncate: 120 }}</div>
+        <div class="description">{{ releaseDetails.series.overview | truncate: 120 }}</div>
         <div class="more-info">
           <a class="btn btn-primary" href="/releases/{{version}}/">
             More info&nbsp;&nbsp;&nbsp;&nbsp;
@@ -66,9 +64,7 @@
         {%- assign sortedReleaseDetails = releaseDetails | sort -%}
         {%- assign lastIndex = sortedReleaseDetails.size | minus: 2 -%}
         {% assign formattedLastVersion = sortedReleaseDetails[lastIndex][0] %}
-        {% assign formattedFirstVersion = sortedReleaseDetails[0][0] %}
         {% assign latestRelease = releaseDetails[formattedLastVersion] %}
-        {% assign firstRelease = releaseDetails[formattedFirstVersion] %}
         {% if latestRelease.stable %}
           {% assign labelStyle = "span label label-stable" %}
           {% assign labelText = "stable" %}
@@ -86,7 +82,7 @@
             <div class="clear"></div>
             <h3 class="version">{{ version }}</h3>
             <h6 class="version-date">{{ latestRelease.date }}</h6>
-            <div class="description">{{ firstRelease.summary }}</div>
+            <div class="description">{{ releaseDetails.series.overview | truncate: 120 }}</div>
             <div class="more-info">
               <a class="btn btn-primary" href="/releases/{{version}}/">
                 More info&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
@gunnarmorling  knowing the char limit(120) I tried to keep the summary sort and in one line. 

And if we wanted to have something like 2 or 3 lines description. I would suggest we keep the existing 120 char inside the box but also show the complete version on the detail page(screen below). At the top just above `Tested versions`
![image](https://user-images.githubusercontent.com/8264372/123833288-d4128b80-d923-11eb-840f-3103ecfbd76b.png)
