### PR TITLE
DBZ-4167 Expands on the Java upgrade breaking change that disables old TLS algorithms

### DIFF
--- a/releases/1.7/release-notes.asciidoc
+++ b/releases/1.7/release-notes.asciidoc
@@ -150,17 +150,17 @@ Gracefully stop the running connector, remove the old plugin files, install the 
 Upon restart, the 1.7.0.CR1 connectors will continue where the previous connector left off.
 As one might expect, all change events previously written to Kafka by the old connector will not be modified.
 
-If you are using our docker images then do not forget to pull them fresh from Docker registry.
+If you are using our container images then do not forget to pull them fresh from Docker registry.
 
 
 === Breaking changes
 
-ZooKeeper, Kafka and Connect images are now based on Fedora base image (https://issues.jboss.org/browse/DBZ-3939[DBZ-3939]).
+The container images for Apache ZooKeeper, Kafka and Connect are now based on Fedora base image (https://issues.jboss.org/browse/DBZ-3939[DBZ-3939]).
 This change was introduced to stay synchronized with the latest Java releases.
 
-A side effect of the Java upgrade is that old unsecure TLS algorithms, namely TLSv1 and TLSv1.1, are disabled on the 1.7 docker images. If your database cannot accept modern TLS connections Debezium will throw `SSLHandshakeException` and fail to connect.
+A side effect of the Java upgrade is that old unsecure TLS algorithms, namely TLSv1 and TLSv1.1, are disabled by default on the 1.7 container images. If your database cannot accept modern TLS connections, Debezium will throw a `SSLHandshakeException` and fail to connect.
 
-If a connection with older algorithms is necessary and you want to rollback this change, the `jdk.tls.disabledAlgorithms` key in the following files need to be edited on the Docker image:
+If a connection with older algorithms is necessary, then remove the entries "TLSv1" and/or "TLSv1.1" from the `jdk.tls.disabledAlgorithms` key in the following files of the Debezium container image for Kafka Connect:
 
 * /etc/crypto-policies/back-ends/java.config
 * /lib/jvm/jre/conf/security/java.security

--- a/releases/1.7/release-notes.asciidoc
+++ b/releases/1.7/release-notes.asciidoc
@@ -158,6 +158,12 @@ If you are using our docker images then do not forget to pull them fresh from Do
 ZooKeeper, Kafka and Connect images are now based on Fedora base image (https://issues.jboss.org/browse/DBZ-3939[DBZ-3939]).
 This change was introduced to stay synchronized with the latest Java releases.
 
+A side effect of the Java upgrade is that old unsecure TLS algorithms, namely TLSv1 and TLSv1.1, are disabled on the 1.7 docker images. If your database cannot accept modern TLS connections Debezium will throw `SSLHandshakeException` and fail to connect.
+
+If a connection with older algorithms is necessary and you want to rollback this change, the `jdk.tls.disabledAlgorithms` key in the following files need to be edited on the Docker image:
+
+* /etc/crypto-policies/back-ends/java.config
+* /lib/jvm/jre/conf/security/java.security
 
 === New Features
 


### PR DESCRIPTION
Issue https://issues.redhat.com/browse/DBZ-4167