### PR TITLE
DBZ-4353 Bump Vitess verion to 12.0.0

### DIFF
--- a/_data/releases/1.8/series.yml
+++ b/_data/releases/1.8/series.yml
@@ -87,5 +87,5 @@ compatibility:
         - 12.0.x
     driver:
       versions:
-        - 12.0.0
+        - 12.0.0*
     note: See the Vitess Connector <a href="/documentation/reference/1.8/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions

--- a/_data/releases/1.8/series.yml
+++ b/_data/releases/1.8/series.yml
@@ -84,9 +84,8 @@ compatibility:
   vitess:
     database:
       versions:
-        - 8.0.x*
-        - 9.0.x
+        - 12.0.x
     driver:
       versions:
-        - 9.0.0
+        - 12.0.0
     note: See the Vitess Connector <a href="/documentation/reference/1.8/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions


### PR DESCRIPTION
Follow up on https://github.com/debezium/debezium-connector-vitess/pull/52 to update the documentation