### PR TITLE
Correct Auto Trader to Auto Trader UK for clarity

### DIFF
--- a/community/users.asciidoc
+++ b/community/users.asciidoc
@@ -15,7 +15,7 @@ If your organization would like to be added to (or removed from) this list,
 please send a pull request for updating the https://github.com/debezium/debezium.github.io/blob/develop/community/users.asciidoc[source of this page] (please keep the list in alphabetic order).
 
 * Airwallex
-* Auto Trader
+* Auto Trader UK
 * Behalf (https://aws.amazon.com/blogs/apn/how-behalf-met-its-streaming-data-scaling-demands-with-amazon-managed-streaming-for-apache-kafka/[details])
 * Bajaj Finserv Health
 * Bolt (https://debezium.io/blog/2020/11/04/streaming-vitess-at-bolt/[details])


### PR DESCRIPTION
Following some healthy internal debate, this PR appends "UK" to the Auto Trader user name for clarity :) 