### PR TITLE
DBZ-5184 Remove Kafka 1.x from Debezium 2.0 test matrix

### DIFF
--- a/_data/releases/2.0/series.yml
+++ b/_data/releases/2.0/series.yml
@@ -18,7 +18,7 @@ compatibility:
   java:
     version: 11+
   connect:
-    version: 1.x, 2.x, 3.x
+    version: 2.x, 3.x
   mysql:
     database:
       versions:


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5184

Once the sibling PR https://github.com/debezium/debezium/pull/3565 is merged, this can be merged to update the website.