### PR TITLE
DBZ-5048 Rename GH repository with container images

### DIFF
--- a/_posts/2017-02-08-Support-for-Postgresql.adoc
+++ b/_posts/2017-02-08-Support-for-Postgresql.adoc
@@ -32,6 +32,6 @@ In general, there are three major steps involved in getting the connector runnin
 2. Setting up the PostgreSQL server with appropriate replication permissions
 3. Starting the Kafka Connect, Broker and Zookeeper machines
 
-For steps 1 and 2 you can check out our https://github.com/debezium/docker-images/tree/master/postgres/9.6[PostgreSQL Docker image] together with the sources for the https://github.com/debezium/postgres-decoderbufs[logical decoding plugin]
+For steps 1 and 2 you can check out our https://github.com/debezium/container-images/tree/master/postgres/9.6[PostgreSQL container image] together with the sources for the https://github.com/debezium/postgres-decoderbufs[logical decoding plugin]
 
-For step 3 you can either use Debezium's https://github.com/debezium/docker-images[Kafka Docker images] or perform a similar setup locally. The https://debezium.io/docs/tutorial[Debezium tutorial] and the https://debezium.io/docs/connectors/postgresql[the connector documentation] are great resources for helping out with this task.
+For step 3 you can either use Debezium's https://github.com/debezium/container-images[Kafka container images] or perform a similar setup locally. The https://debezium.io/docs/tutorial[Debezium tutorial] and the https://debezium.io/docs/connectors/postgresql[the connector documentation] are great resources for helping out with this task.

--- a/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
+++ b/_posts/2019-07-08-tutorial-sentry-debezium-container-images.adoc
@@ -138,4 +138,4 @@ As an example how a `RecordTooLarge` exception from the Kafka producer would loo
 Thanks to the recent refactor of the Debezium container images, it got very easy to amend them with your custom extensions.
 Downloading external dependencies and adding them to the images became a trivial task and we'd love to hear your feedback about it!
 
-If you are curious about the refactoring itself, you can find the details in pull request https://github.com/debezium/docker-images/pull/131[debezium/docker-images#131].
+If you are curious about the refactoring itself, you can find the details in pull request https://github.com/debezium/container-images/pull/131[debezium/container-images#131].

--- a/_posts/2021-08-31-going-zookeeperless-with-debezium-container-image-for-apache-kafka.adoc
+++ b/_posts/2021-08-31-going-zookeeperless-with-debezium-container-image-for-apache-kafka.adoc
@@ -146,7 +146,7 @@ Eventually, the option to run with ZooKeeper will be removed, but it'll be quite
 
 To learn more about KRaft, refer to https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum[KIP-500] and related KIPs, which describe the feature and its design in great detail,
 the https://github.com/apache/kafka/blob/trunk/config/kraft/README.md[KRaft README file],
-https://github.com/debezium/docker-images/tree/main/kafka/1.7[the README] of the Debezium 1.7 container image for Apache Kafka,
+https://github.com/debezium/container-images/tree/main/kafka/1.7[the README] of the Debezium 1.7 container image for Apache Kafka,
 and aforementioned blog post https://www.morling.dev/blog/exploring-zookeeper-less-kafka/["Exploring ZooKeeper-less Kafka"].
 
 _Many thanks to https://twitter.com/rk3rn3r/[René Kerner] for providing feedback while writing this post._


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5048

There are still some mentions of `docker-images` in the old documentations, but it would mean to rewrite git history in the main repo, so there's probably nothing we can do about it. Besides documentation I find anything else but the places fixed in this PR.