### PR TITLE
Added Myntra as a User

### DIFF
--- a/community/users.asciidoc
+++ b/community/users.asciidoc
@@ -33,6 +33,7 @@ please send a pull request for updating the https://github.com/debezium/debezium
 * Klabin S.A.
 * Lendingkart Tech
 * MEGOGO
+* Myntra (https://medium.com/myntra-engineering/sourcerer-data-ingestion-at-myntra-4841d12daad8[details])
 * OYO
 * Pipedrive
 * Reddit (https://old.reddit.com/r/RedditEng/comments/qkfx7a/change_data_capture_with_debezium/[details])


### PR DESCRIPTION
Myntra heavily uses Debezium for ingesting CDC Data. 

Added Myntra as a User -- Update community/users.asciidoc