### PR TITLE
DBZ-5900: Fix the Debezium UI doc link visibility

### DIFF
--- a/_antora/supplemental_ui/css/debezium-antora.css
+++ b/_antora/supplemental_ui/css/debezium-antora.css
@@ -199,6 +199,11 @@ body.version-1-0 table.tableblock tr:nth-of-type(even) {
   z-index: 10;
   text-transform: capitalize;
 }
+
+.nav-panel-menu {
+  margin-bottom: calc(50% - 5rem);
+}
+
 .nav-panel-explore .context .version,
 .nav-panel-explore .versions {
   text-transform: capitalize;


### PR DESCRIPTION
Screenshot:
Debezium UI link is now visible in the bottom left corner 
<img width="1721" alt="image" src="https://user-images.githubusercontent.com/8264372/207834430-0338053f-4f82-4266-9d67-7a777c17a3f2.png">
