### PR TITLE
doc: Add Okta (Auth0) to `users.asciidoc`.

### DIFF
--- a/community/users.asciidoc
+++ b/community/users.asciidoc
@@ -34,6 +34,7 @@ please send a pull request for updating the https://github.com/debezium/debezium
 * Lendingkart Tech
 * MEGOGO
 * Myntra (https://medium.com/myntra-engineering/sourcerer-data-ingestion-at-myntra-4841d12daad8[details])
+* Okta (Auth0) (https://auth0.com/blog/data-pipelines-on-auth0-s-new-private-cloud-platform/[details])
 * OYO
 * Pipedrive
 * Reddit (https://old.reddit.com/r/RedditEng/comments/qkfx7a/change_data_capture_with_debezium/[details])


### PR DESCRIPTION
Adds Okta to the list of users of Debezium to https://debezium.io/community/users per [Data Pipelines on Auth0’s New Private Cloud Platform](https://auth0.com/blog/data-pipelines-on-auth0-s-new-private-cloud-platform/):

<img width="396" alt="image" src="https://user-images.githubusercontent.com/2717578/224401810-fecc4d85-43e7-4382-a3c6-89e230d34898.png">
