### PR TITLE
DBZ-2543 Add OpenLogReplicator to tested matrix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -156,3 +156,30 @@ integrations:
     name: Vitess
   - id: jdbc
     name: JDBC sink
+
+# Controls what tested version attributes are shown for each integration
+# Used by the tested-integration-column.html and tested-integration-attribute.html include fragments
+#
+# Features:
+#   * attributes can have 1-depth level of children, see database plugins
+#   * attributes can define that their label be hidden, see version used for Java and Kafka
+#
+# Notes:
+#   For simplicity, the JDBC Driver label has been renamed to simply Driver. This allows a single label
+#   to be used for both relational databases and non-relational databases, Cassandra and MongoDB.
+#
+test_attributes:
+  - id: database
+    name: Database
+    children:
+      - id: plugins
+        name: Plug-ins
+  - id: databases
+    name: Databases
+  - id: driver
+    name: Driver
+  - id: olr
+    name: OpenLogReplicator
+  - id: version
+    name: Version
+    hide_label: true

--- a/_data/releases/2.2/series.yml
+++ b/_data/releases/2.2/series.yml
@@ -113,10 +113,9 @@ compatibility:
         - 12.0.0*
     note: See the Vitess Connector <a href="/documentation/reference/2.0/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions
   jdbc:
-    database:
-      vendors:
-        - Db2
-        - MySQL
-        - Oracle
-        - PostgreSQL
-        - SQL Server
+    databases:
+      - Db2
+      - MySQL
+      - Oracle
+      - PostgreSQL
+      - SQL Server

--- a/_data/releases/2.3/series.yml
+++ b/_data/releases/2.3/series.yml
@@ -114,10 +114,9 @@ compatibility:
         - 12.0.0*
     note: See the Vitess Connector <a href="/documentation/reference/2.0/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions
   jdbc:
-    database:
-      vendors:
-        - Db2
-        - MySQL
-        - Oracle
-        - PostgreSQL
-        - SQL Server
+    databases:
+      - Db2
+      - MySQL
+      - Oracle
+      - PostgreSQL
+      - SQL Server

--- a/_data/releases/2.4/series.yml
+++ b/_data/releases/2.4/series.yml
@@ -70,13 +70,12 @@ compatibility:
         - 21c
     driver:
       versions:
-        - 12.2.0.1
-        - 19.8.0.0
-        - 21.1.0.0
-        - 21.3.0.0
-        - 21.4.0.0
-        - 21.5.0.0
-        - 21.6.0.0
+        - 12.2.x
+        - 19.x
+        - 21.x
+    olr:
+      versions:
+        - 1.2.1
   cassandra-3:
     database:
       versions:
@@ -114,10 +113,9 @@ compatibility:
         - 12.0.0*
     note: See the Vitess Connector <a href="/documentation/reference/2.0/connectors/vitess.html#limitations-with-earlier-vitess-versions">documentation</a> for limitations when using the connector with earlier Vitess versions
   jdbc:
-    database:
-      vendors:
-        - Db2
-        - MySQL
-        - Oracle
-        - PostgreSQL
-        - SQL Server
+    databases:
+      - Db2
+      - MySQL
+      - Oracle
+      - PostgreSQL
+      - SQL Server

--- a/_includes/release-version.html
+++ b/_includes/release-version.html
@@ -14,7 +14,7 @@
 <h3 class="section" id="compatibility">Tested Versions</h3>
 
 {% assign formattedVersion = page.debezium-version | replace: ".", "" %}
-{% assign releaseDetails = site.data.releases[formattedVersion] %} 
+{% assign releaseDetails = site.data.releases[formattedVersion] %}
 
 <table class="releases-compatibility">
   <tbody>
@@ -23,42 +23,13 @@
       {% if compat != null %}
         <tr>
           <td>{{ integration.name }}</td>
-            {% assign version = compat.version %}
-            {% assign dbVersions = compat.database.versions %}
-            {% assign dbVendors = compat.database.vendors %}
-            {% assign driverVersions = compat.driver.versions %}
-            {% assign plugins = compat.database.plugins %}
-            {% if version != null %}
-              <td>{{ version }}</td>
-            {% elsif dbVendors != null %}
-              <td>
-                <span class="test-with-subcategory"> Databases: </span> {{ dbVendors | join: ", " }} <br/>
-              </td>
-            {% elsif dbVersions != null %}
-              <td>
-                <span class="test-with-subcategory"> Database: </span> {{ dbVersions  | join: ", "  }} <br />
-                {% if integration.name == 'Cassandra'	or integration.name == 'MongoDB' %}
-                  <span class="test-with-subcategory"> Driver: </span> {{ driverVersions  | join: ", "  }} <br />
-                {% else %}
-                  <span class="test-with-subcategory"> JDBC Driver: </span> {{ driverVersions  | join: ", "  }} <br />
-                {% endif %}
-                {% if integration.name == 'PostgreSQL' and plugins != null %}
-                  <span class="test-with-subcategory"> Plug-ins:</span> {{ plugins  | join: ", "  }} <br />
-                {% endif %}
-                {% if compat.note != null %}
-                  <span class="test-with-subcategory"> * {{ compat.note  }} </span> <br />
-                {% endif %}
-              </td>
-            {% endif %}
+          {% include tested-integration-column.html %}
         </tr>
-      {% else %}
-        <!--
-        <tr><td>{{ integration.name }}</td><td>N/A</td></tr>
-        -->
       {% endif %}
     {% endfor %}
   </tbody>
 </table>
+
 <p>
   Not compatible with your requirements? Have a look at the
   <a href="/releases">other series</a>. <br />

--- a/_includes/release.html
+++ b/_includes/release.html
@@ -131,37 +131,7 @@
           {% if releaseDetails.series.displayed %}
             {% assign compat = releaseDetails.series.compatibility[integration.id] %}
             {% if compat != null %}
-              {% assign compatVersion = compat.version %}
-              {% assign dbVersions = compat.database.versions %}
-              {% assign dbVendors = compat.database.vendors %}
-              {% assign driverVersions = compat.driver.versions %}
-              {% assign plugins = compat.database.plugins %}
-              {% if compatVersion != null %}
-                <td>{{ compatVersion }}</td>
-              {% elsif dbVendors != null %}
-              <td>
-                <span class="test-with-subcategory"> Databases: </span> {{ dbVendors | join: ", " }} <br/>
-              </td>
-              {% elsif dbVersions != null %}
-                <td>
-                  <span class="test-with-subcategory"> Database: </span> {{ dbVersions  | join: ", "  }} <br />
-                  {% if integration.name == 'Cassandra'	or integration.name == 'MongoDB' %}
-                    <span class="test-with-subcategory"> Driver:</span> {{ driverVersions  | join: ", "  }} <br />
-                  {% else %}
-                    <span class="test-with-subcategory"> JDBC Driver: </span> {{ driverVersions  | join: ", "  }} <br />
-                  {% endif %}
-                  {% if integration.name == 'PostgreSQL' and plugins != null %}
-                    <span class="test-with-subcategory"> Plug-ins:</span> {{ plugins  | join: ", "  }} <br />
-                  {% endif %}
-                  {% if compat.note != null %}
-                    <span class="test-with-subcategory"> * {{ compat.note  }} </span> <br />
-                  {% endif %}
-                </td>
-              {% endif %}
-            {% else %}
-              <td>
-                N/A
-              </td>
+              {% include tested-integration-column.html %}
             {% endif %}
           {% endif %}
         {% endfor %}

--- a/_includes/tested-integration-attribute.html
+++ b/_includes/tested-integration-attribute.html
@@ -1,0 +1,11 @@
+{% if render_attribute.hide_label == null or render_attribute.hide_label == false %}
+<span class="test-with-subcategory">{{ render_attribute.name }}: </span>
+{% endif %}
+{% if integration_attribute.versions != null %}
+  {{ integration_attribute.versions | join: ", " }}
+{% elsif integration_attribute.first %}
+  {{ integration_attribute | join: ", " }}
+{% else %}
+  {{ integration_attribute }}
+{% endif %}
+<br/>

--- a/_includes/tested-integration-column.html
+++ b/_includes/tested-integration-column.html
@@ -1,0 +1,20 @@
+<td>
+  {% for attribute in site.test_attributes %}
+    {% assign integration_attribute = compat[attribute.id] %}
+    {% if integration_attribute != null %}
+      {% assign render_attribute = attribute %}
+      {% include tested-integration-attribute.html %}
+      {% for child in attribute.children %}
+        {% assign child_integration_attribute = compat[attribute.id][child.id] %}
+        {% if child_integration_attribute != null %}
+          {% assign render_attribute = child %}
+          {% assign integration_attribute = child_integration_attribute %}
+          {% include tested-integration-attribute.html %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+  {% if compat.note != null %}
+    <span class="test-with-subcategory"> * {{ compat.note  }} </span> <br />
+  {% endif %}
+</td>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-2543

### Changes

It seemed prudent to rework the integration attributes and how they were defined to avoid needing to hardcode these values in the HTML, so now the integration attributes are defined in _config.yml and used in the two new html fragments:

  tested-integration-attribute.html
  tested-integration-column.html

See details in _config.yml about features and limitations of this change.

Going forward, this should make it easier to not only add new attributes as we see fit, but to also more easily edit the rendered website bits as the two test matrices used at https://debezium.io/releases and https://debezium.io/releases/2.4 (version-specific) are now shared.