### PR TITLE
Add a more info link into the feel for truncated content

### DIFF
--- a/blog.atom
+++ b/blog.atom
@@ -23,7 +23,8 @@ layout: none
 					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
 				{% endif %}
 				{% if post.excerpt %}
-					<description>{{ post.excerpt | xml_escape }}</description>
+ 					{% assign moreHtml = "<br/><a href='" + site.url + "/" + {{ page.path }} + "'>Read more...</a>" %}
+ 					<description>{{ post.excerpt | xml_escape }} {{ moreHtml | xml_escape }}</description>
 				{% else %}
 					<description>{{ post.content | xml_escape }}</description>
 				{% endif %}


### PR DESCRIPTION
When using a RSS reader, it is unclear that the content of the blog is longer than the excerpt. A classical way to make it clearer is to add a read more link. This is what this PR is doing. 
I have not been able to test it as the local docker run fails for me (amd64 vs arm64 issue).

 Note, I personally hate when blogs create excerpts as it ruins the RSS reader experience. So best would be to remove the exerpt block and always show the full content IMO.

