### PR TITLE
Fix blog feed - Fix liquid string concatenation

### DIFF
--- a/blog.atom
+++ b/blog.atom
@@ -23,7 +23,7 @@ layout: none
 					<dc:creator>{{ post.author.name | xml_escape }}</dc:creator>
 				{% endif %}
 				{% if post.excerpt %}
- 					{% assign moreHtml = "<br/><a href='" + site.url + "/" + {{ page.path }} + "'>Read more...</a>" %}
+  					{% capture moreHtml %}<br/><a href="{{ site.url }}/{{ page.path }}">Read more...</a>{% endcapture %}
  					<description>{{ post.excerpt | xml_escape }} {{ moreHtml | xml_escape }}</description>
 				{% else %}
 					<description>{{ post.content | xml_escape }}</description>


### PR DESCRIPTION
@Naros sorry looks like Liquid string contatenation is not how I imagined it woudl work. This should be better but you can check by running locally and hitting `/blog.atom` The end of the description should have `Read more...`.