### PR TITLE
Adding a link to my tutorial with sample code

### DIFF
--- a/documentation/online-resources.asciidoc
+++ b/documentation/online-resources.asciidoc
@@ -210,6 +210,7 @@ CDC in Azure Database for MySQL – Flexible Server using Kafka, Debezium, and A
 * https://github.com/hyagli/cdc-python-netcore/["Outbox Pattern Implementation using Debezium and Google Protocol Buffers"] by Huseyin Yagli
 * https://youtu.be/fQoTvEtho_4/["Monitoring Kafka Debezium Connector metrics using Prometheus"] by Waqas Dilawar
 * https://github.com/nmertaydin/mysql-debezium-kafka-pinot["MySQL Debezium Kafka Pinot CDC Flow"] by Nurettin Mert Aydin
+* https://github.com/ycamargo/debezium-on-aks["Tutorial - CDC with Debezium running on AKS and sending events to Azure Event Hub"] by Yuri Camargo
 
 == Interviews and Podcasts
 


### PR DESCRIPTION
I've made a tutorial, in 2021, about how to deploy Debezium on Azure Kubernetes Services and sending events to Azure Event Hub. 
I've updated this tutorial in 2023 to use the new features of the latest versions of Debezium, Kafka Connect, Strimzi, and Event Hub.