### PR TITLE
Update Hazelcast link and name

### DIFF
--- a/community/users.asciidoc
+++ b/community/users.asciidoc
@@ -78,7 +78,7 @@ Debezium is also integrated with and used by a number of downstream 3rd-party pr
 * https://www.floodplain.io[Floodplain]
 * https://github.com/memiiso/debezium-server-bigquery[Google BigQuery]
 * https://cloud.google.com/blog/products/data-analytics/how-to-move-data-from-mysql-to-bigquery[Google Cloud DataFlow]
-* https://jet-start.sh/docs/tutorials/cdc[Hazecast Jet]
+* https://docs.hazelcast.com/hazelcast/latest/integrate/cdc-connectors[Hazelcast Platform]
 * https://devcenter.heroku.com/articles/heroku-data-connectors[Heroku’s Streaming Data Connectors]
 * https://ibm.github.io/event-streams/connectors/[IBM Event Streams]
 * https://materialize.io/docs/third-party/debezium/[Materialize]


### PR DESCRIPTION
Hazelcast Jet is now a part of Hazelcast Platform, reflecting this change in the name. Also updated link