### PR TITLE
Fix MariaDB download link

### DIFF
--- a/_data/connectors.yml
+++ b/_data/connectors.yml
@@ -4,7 +4,7 @@ connectors:
     artifact: debezium-connector-mysql
   - id: mariadb
     title: MariaDB Connector Plug-in
-    artifact: debezium-connector-mysql
+    artifact: debezium-connector-mariadb
   - id: mongodb
     title: MongoDB Connector Plug-in
     artifact: debezium-connector-mongodb


### PR DESCRIPTION
Current link for downloading MariaDB points to MySQL connector.