### PR TITLE
Fix postgres-plugin redirect to expected target

### DIFF
--- a/redirects/docs_install_postgres-plugins.asciidoc
+++ b/redirects/docs_install_postgres-plugins.asciidoc
@@ -1,5 +1,5 @@
 ---
 permalink: /docs/install/postgres-plugins/
 layout: redirect
-redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/postgres_plugins.html
+redir_to: /documentation/reference/!LATEST_STABLE_VERSION!/postgres-plugins.html
 ---


### PR DESCRIPTION
Redirect would result in a 404 because target link uses a hyphen, not underscore, for postgres-plugins.