### PR TITLE
[ci] CI should fail on bad builds

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,13 +45,13 @@ task :default => :build
 desc 'Install the environment to run Jekyll'
 task :install do
   system 'bundle install'
-  exit 0
+  exit 1 unless $?.success?
 end
 
 desc 'Update the environment to run Jekyll'
 task :update do
   system 'bundle update'
-  exit 0
+  exit 1 unless $?.success?
 end
 
 desc 'Build and preview the site locally in development mode'
@@ -61,7 +61,11 @@ task :preview do
   create_context7_files()
 
   system 'bundle install'
+  exit 1 unless $?.success?
+
   system "#{$use_bundle_exec ? 'bundle exec ' : ''}jekyll serve --host 0.0.0.0 --livereload" or raise "Jekyll build failed"
+  exit 1 unless $?.success?
+
 end
 
 desc 'Build the site for the given environment: development (the default), staging, or production'
@@ -70,7 +74,11 @@ task :build, [:environment] do |task, args|
 
   run_antora
   system 'bundle install'
+  exit 1 unless $?.success?
+
   system "JEKYLL_ENV=#{args[:environment]} bundle exec jekyll build"
+  exit 1 unless $?.success?
+
   clone_versions
 
   create_context7_files()

--- a/_scripts/create-snapshot-links.sh
+++ b/_scripts/create-snapshot-links.sh
@@ -16,10 +16,30 @@ update_snapshot_link() {
     local COMPONENT=$1
     local ARTIFACT_ID=$2
     local CLASSIFIER=$3
+    local MAX_RETRIES=3
+    local RETRY_DELAY=5
 
-    SNAPSHOT_VERSION=$(curl --silent -fSL $MAVEN_REPO/$GROUP_ID/$ARTIFACT_ID/$DEBEZIUM_VERSION/maven-metadata.xml | awk -F'<[^>]+>' '/<extension>tar.gz<\/extension>/ {getline; print $2; exit}')
+    echo "Fetching $COMPONENT metadata"
+    for ((i=1; i<=MAX_RETRIES; i++)); do
+      SNAPSHOT_VERSION=$(curl --connect-timeout 10 --max-time 30 --silent -fSL $MAVEN_REPO/$GROUP_ID/$ARTIFACT_ID/$DEBEZIUM_VERSION/maven-metadata.xml | awk -F'<[^>]+>' '/<extension>tar.gz<\/extension>/ {getline; print $2; exit}')
+
+      if [[ -n "$SNAPSHOT_VERSION" ]]; then
+        break
+      fi
+
+      echo " Attempt $i/$MAX_RETRIES failed for $COMPONENT, retrying"
+      sleep "$RETRY_DELAY"
+      RETRY_DELAY=$((RETRY_DELAY * 2))
+    done
+
+    if [[ -z "$SNAPSHOT_VERSION" ]]; then
+      echo "ERROR: Failed to resolve snapshot for $COMPONENT after $MAX_RETRIES retries"
+      return 1
+    fi
+
     SNAPSHOT_LINK="$MAVEN_REPO/$GROUP_ID/$ARTIFACT_ID/$DEBEZIUM_VERSION/$ARTIFACT_ID-${SNAPSHOT_VERSION}${CLASSIFIER}.tar.gz"
     sed -i "s#link-$COMPONENT-snapshot:.*#link-$COMPONENT-snapshot: \'$SNAPSHOT_LINK\'#" $ANTORA_FILE
+    echo "Updated $COMPONENT as $SNAPSHOT_LINK"
 }
 
 for CONNECTOR in "${CONNECTORS[@]}"; do


### PR DESCRIPTION
This PR does the following:

* When any `rake` call out to `system` fails, we make sure that the error code is propagated back up to the GHA runtime. So, in the case of the YAML incident, this PR would fail, as is evident in this PR.
* In addition, I've also noticed that in some instances, the snapshot metadata update script is being throttled back on Maven Central, likely due to oversaturation. To address that, the script has been modified to include a retry mechanism and will also propagate error codes up the stack if it fails as part of the GHA pipeline.

If this looks good, I just need to remove the test commit to illustate the behavior.