### PR TITLE
debezium/dbz#1883 Add redirect after extension rename

### DIFF
--- a/redirects/debezium-quarkus-engine-extension-non-filtered.asciidoc
+++ b/redirects/debezium-quarkus-engine-extension-non-filtered.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/reference/$%7BparsedVersion.majorVersion%7D.$%7BparsedVersion.minorVersion%7D/integrations/debezium-quarkus-engine-extension.html
+layout: redirect
+redir_to: /documentation/reference/stable/integrations/quarkus-debezium-engine-extension.html
+---

--- a/redirects/debezium-quarkus-engine-extension.asciidoc
+++ b/redirects/debezium-quarkus-engine-extension.asciidoc
@@ -1,0 +1,5 @@
+---
+permalink: /documentation/reference/3.5/integrations/debezium-quarkus-engine-extension.html
+layout: redirect
+redir_to: /documentation/reference/3.5/integrations/quarkus-debezium-engine-extension.html
+---


### PR DESCRIPTION
Fixes debezium/dbz#1883

## Description
Adds a redirect for the old 3.5 link [documentation/reference/3.5/integrations/debezium-quarkus-engine-extension.html](https://debezium.io/documentation/reference/3.5/integrations/debezium-quarkus-engine-extension.html) so that it points to the newly renamed `quarkus-debezium-engine-extension.html` file, for quarkus.io references. Additionally adds a temporary redirect for the unfiltered resource link for Quarkus extensions so that at least the user lands on the proper page.
