### PR TITLE
[ci] Switch comment actions

### DIFF
--- a/.github/workflows/surge-preview-start.yml
+++ b/.github/workflows/surge-preview-start.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: create
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: marocchino/sticky-pull-request-comment@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          header: surge-preview
+          message: |
             ⚡️ Deploying PR Preview...
             <img src="https://user-images.githubusercontent.com/507615/90240294-8d2abd00-de5b-11ea-8140-4840a0b2d571.gif" width="300" />
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'

--- a/.github/workflows/surge-preview.yml
+++ b/.github/workflows/surge-preview.yml
@@ -40,28 +40,28 @@ jobs:
           export DEPLOY_DOMAIN=https://debezium-debezium-github-io-preview-pr-${{ steps.pr.outputs.id }}.surge.sh
           npx surge --project ./ --domain $DEPLOY_DOMAIN --token ${{ secrets.SURGE_TOKEN }}
       - name: update status comment
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: marocchino/sticky-pull-request-comment@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            🎊 PR Preview has been successfully built and deployed to https://debezium-debezium-github-io-preview-pr-${{ steps.pr.outputs.id }}.surge.sh
-            
-            <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
+          header: surge-preview
           number: ${{ steps.pr.outputs.id }}
+          message: |
+            🎊 PR Preview has been successfully built and deployed to https://debezium-debezium-github-io-preview-pr-${{ steps.pr.outputs.id }}.surge.sh
+
+            <img width="300" src="https://user-images.githubusercontent.com/507615/90250366-88233900-de6e-11ea-95a5-84f0762ffd39.png">
 
       - name: The job failed
         if: ${{ failure() }}
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: marocchino/sticky-pull-request-comment@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          header: surge-preview
+          number: ${{ steps.pr.outputs.id }}
+          message: |
             😭 Deploy PR Preview failed.
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ steps.pr.outputs.id }}
 
   failed:
     runs-on: ubuntu-latest
@@ -79,12 +79,12 @@ jobs:
         run: echo "id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
       - name: The job failed
-        uses: actions-cool/maintain-one-comment@v3.2.0
+        uses: marocchino/sticky-pull-request-comment@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
+          header: surge-preview
+          number: ${{ steps.pr.outputs.id }}
+          message: |
             😭 Deploy PR Preview failed.
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ steps.pr.outputs.id }}


### PR DESCRIPTION
The actions-cool/maintain-one-comment action has been blocked by GitHub, and so this changes to a new action that provides the same feature set.