### PR TITLE
dbz#2211 fixed script that generates links for each doc version

### DIFF
--- a/_antora/supplemental_ui/partials/page-versions.hbs
+++ b/_antora/supplemental_ui/partials/page-versions.hbs
@@ -9,9 +9,9 @@
                     <a class="version is-missing" href="#">{{./displayVersion}}</a>
                 {{else}}
                     {{#if (eq ./version @root.page.version)}}
-                        <a class="version is-current" href="{{this.url}}" data-hash="true">{{./displayVersion}}</a>
+                        <a class="version is-current" href="/documentation{{this.url}}" data-hash="true">{{./displayVersion}}</a>
                     {{else}}
-                        <a class="version" href="/documentation/{{this.url}}" data-hash="true">{{./displayVersion}}</a>
+                        <a class="version" href="/documentation{{this.url}}" data-hash="true">{{./displayVersion}}</a>
                     {{/if}}
                 {{/if}}
             {{/each}}


### PR DESCRIPTION
The link to the current version was missing `documentation` before it. It also appears that `{{this.url}}` already has a forward slash at the start so there is no need for one after `documentation`.
