### PR TITLE
fix: wrong link for Debezium Platform in blog post

### DIFF
--- a/_posts/2026-05-22-what-nobody-explains-about-debezium-2026.adoc
+++ b/_posts/2026-05-22-what-nobody-explains-about-debezium-2026.adoc
@@ -44,7 +44,7 @@ For teams that don't need the full Kafka ecosystem, or that prefer a lighter-wei
 https://debezium.io/documentation/reference/stable/operations/debezium-server.html[Debezium Server] is a standalone, ready-to-run application that provides native connectivity with other streaming platforms and messaging systems: Amazon Kinesis, Google Cloud Pub/Sub, Apache Pulsar, Redis Streams, RabbitMQ, HTTP webhooks, and more.
 If your organization is already invested in one of these ecosystems, Debezium Server lets you bring CDC to that platform directly, using the same proven source connectors, without introducing Kafka as an additional layer.
 
-https://debezium.io/documentation/reference/stable/platform/index.html[Debezium Platform] takes this further, providing an operator-based deployment model that manages the full lifecycle of Debezium connectors, including configuration, scaling, and health management, all without requiring any Kafka ecosystem components.
+https://debezium.io/documentation/reference/stable/operations/debezium-platform.html[Debezium Platform] takes this further, providing an operator-based deployment model that manages the full lifecycle of Debezium connectors, including configuration, scaling, and health management, all without requiring any Kafka ecosystem components.
 
 The perception that Debezium requires Kafka persists in part because many tutorials were written before these options existed and are still widely shared.
 In many deployments today, Kafka is not part of the architecture at all.


### PR DESCRIPTION
Fixes a broken URL in the blog post `_posts/2026-05-22-what-nobody-explains-about-debezium-2026.adoc`. 