### PR TITLE
Add Paystack to list of Debezium users

### DIFF
--- a/community/users.asciidoc
+++ b/community/users.asciidoc
@@ -40,6 +40,7 @@ please send a pull request for updating the https://github.com/debezium/debezium
 * Myntra (https://medium.com/myntra-engineering/sourcerer-data-ingestion-at-myntra-4841d12daad8[details])
 * Okta (Auth0) (https://auth0.com/blog/data-pipelines-on-auth0-s-new-private-cloud-platform/[details])
 * OYO
+* Paystack
 * Pipedrive
 * Reddit (https://old.reddit.com/r/RedditEng/comments/qkfx7a/change_data_capture_with_debezium/[details])
 * Segment (used with https://ctlstore.segment.com/[ctlstore])


### PR DESCRIPTION
Paystack is using Debezium in production, and we'd like to be added to the public users list, as suggested on the page.

Added in alphabetical order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)